### PR TITLE
contrib: EOS portable archive; be kind to older Boost versions

### DIFF
--- a/contrib/eos_portable_archive/eos/portable_iarchive.hpp
+++ b/contrib/eos_portable_archive/eos/portable_iarchive.hpp
@@ -119,6 +119,7 @@
 // Boost 1.69 (Spirit.X2/X3) has dropped their own FP routines in favor of boost::math
 #elif BOOST_VERSION < 106900
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
+#include <boost/spirit/home/support/detail/endian/endian.hpp>
 #else
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #endif

--- a/contrib/eos_portable_archive/eos/portable_oarchive.hpp
+++ b/contrib/eos_portable_archive/eos/portable_oarchive.hpp
@@ -122,6 +122,7 @@
 // Boost 1.69 (Spirit.X2/X3) has dropped their own FP routines in favor of boost::math
 #elif BOOST_VERSION < 106900
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
+#include <boost/spirit/home/support/detail/endian/endian.hpp>
 #else
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #endif


### PR DESCRIPTION
Fixes broken build for Boost < 1.69