### PR TITLE
Zano: resolve Clang build warnings

### DIFF
--- a/src/currency_core/bc_attachments_service_manager.h
+++ b/src/currency_core/bc_attachments_service_manager.h
@@ -12,6 +12,8 @@ namespace currency
 {
   struct i_bc_service
   {
+    virtual ~i_bc_service() = default;
+
     virtual std::string get_id() = 0;
     virtual bool init(const std::string& config_folder, const boost::program_options::variables_map& vm) = 0;
     virtual bool deinit() = 0;

--- a/src/currency_core/blockchain_storage.cpp
+++ b/src/currency_core/blockchain_storage.cpp
@@ -3544,7 +3544,7 @@ bool blockchain_storage::check_tx_inputs(const transaction& tx, const crypto::ha
   if (!m_is_in_checkpoint_zone)
   {
     CHECK_AND_ASSERT_MES(tx.signatures.size() == sig_index, false, "tx signatures count differs from inputs");
-    if (!get_tx_flags(tx)&TX_FLAG_SIGNATURE_MODE_SEPARATE)
+    if (!(get_tx_flags(tx) & TX_FLAG_SIGNATURE_MODE_SEPARATE))
     {
       bool r = validate_attachment_info(tx.extra, tx.attachment, false);
       CHECK_AND_ASSERT_MES(r, false, "Failed to validate attachments in tx " << tx_prefix_hash << ": incorrect extra_attachment_info in tx.extra");

--- a/src/currency_core/currency_format_utils.cpp
+++ b/src/currency_core/currency_format_utils.cpp
@@ -1109,7 +1109,7 @@ namespace currency
         att_count++;
       }
     }
-    if (!flags&TX_FLAG_SIGNATURE_MODE_SEPARATE)
+    if (!(flags & TX_FLAG_SIGNATURE_MODE_SEPARATE))
     {
       //take hash from attachment and put into extra
       if (tx.attachment.size())
@@ -2374,7 +2374,7 @@ namespace currency
   //---------------------------------------------------------------
   bool is_pos_block(const block& b)
   {
-    if (!b.flags&CURRENCY_BLOCK_FLAG_POS_BLOCK)
+    if (!(b.flags & CURRENCY_BLOCK_FLAG_POS_BLOCK))
       return false;
     return is_pos_block(b.miner_tx);
   }

--- a/src/gui/qt-daemon/application/core_fast_rpc_proxy.h
+++ b/src/gui/qt-daemon/application/core_fast_rpc_proxy.h
@@ -124,7 +124,7 @@ namespace tools
       return m_rpc.on_get_current_core_tx_expiration_median(req, res, m_cntxt_stub);
     }
     //------------------------------------------------------------------------------------------------------------------------------
-    bool call_COMMAND_RPC_GET_POOL_INFO(const currency::COMMAND_RPC_GET_POOL_INFO::request& req, currency::COMMAND_RPC_GET_POOL_INFO::response& res)
+    bool call_COMMAND_RPC_GET_POOL_INFO(const currency::COMMAND_RPC_GET_POOL_INFO::request& req, currency::COMMAND_RPC_GET_POOL_INFO::response& res) override
     {
       return m_rpc.on_get_pool_info(req, res, m_cntxt_stub);
     }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1401,7 +1401,7 @@ int main(int argc, char* argv[])
     bool r = wrpc.init(vm);
     CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize wallet rpc server");
 
-    tools::signal_handler::install([&wrpc, &wal] {
+    tools::signal_handler::install([&wrpc/*, &wal*/ /* TODO(unassigned): use? */] {
       wrpc.send_stop_signal();
     });
     LOG_PRINT_L0("Starting wallet rpc server");

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -22,7 +22,7 @@ namespace currency
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
-  class simple_wallet : public tools::i_wallet2_callback, 
+  class simple_wallet final : public tools::i_wallet2_callback,
                         public std::enable_shared_from_this<simple_wallet>
   {
   public:

--- a/src/wallet/core_default_rpc_proxy.h
+++ b/src/wallet/core_default_rpc_proxy.h
@@ -16,7 +16,7 @@
 
 namespace tools
 {
-  class default_http_core_proxy: public i_core_proxy
+  class default_http_core_proxy final : public i_core_proxy
   {
   public:
 

--- a/src/wallet/core_rpc_proxy.h
+++ b/src/wallet/core_rpc_proxy.h
@@ -16,6 +16,8 @@ namespace tools
   */
   struct i_core_proxy
   {
+    virtual ~i_core_proxy() = default;
+
     virtual bool set_connection_addr(const std::string& url){ return false; }
     virtual bool call_COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES(const currency::COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::request& rqt, currency::COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::response& rsp){ return false; }
     virtual bool call_COMMAND_RPC_GET_BLOCKS_FAST(const currency::COMMAND_RPC_GET_BLOCKS_FAST::request& rqt, currency::COMMAND_RPC_GET_BLOCKS_FAST::response& rsp){ return false; }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -68,6 +68,8 @@ namespace tools
   class i_wallet2_callback
   {
   public:
+    virtual ~i_wallet2_callback() = default;
+
     virtual void on_new_block(uint64_t /*height*/, const currency::block& /*block*/) {}
     virtual void on_transfer2(const wallet_rpc::wallet_transfer_info& wti, uint64_t balance, uint64_t unlocked_balance, uint64_t total_mined) {}
     virtual void on_pos_block_found(const currency::block& /*block*/) {}

--- a/tests/core_tests/pos_validation.cpp
+++ b/tests/core_tests/pos_validation.cpp
@@ -989,7 +989,7 @@ bool pos_altblocks_validation::generate(std::vector<test_event_entry>& events) c
   //          ||         \-  (2a)-   #3a#-                 |                     <- alt chain
   //          |+--------------+ \     |                    \                     PoS block 2a uses stake already spent in main chain (okay)
   //          +---------------|-------+                     \                    PoS block 3a uses stake already spent in current alt chain (fail)
-  //                          |   \                          \  
+  //                          |   \                          \
   //                          |    \ ...... (2br)-   (3b)-   #4b#                <- alt chain
   //                          |                       |
   //                          +-----------------------+                          PoS block 3b uses as stake an output, created in current alt chain (2a)

--- a/tests/core_tests/test_core_proxy.h
+++ b/tests/core_tests/test_core_proxy.h
@@ -12,6 +12,8 @@
 class test_core_listener
 {
 public:
+  virtual ~test_core_listener() = default;
+
   virtual void before_tx_pushed_to_core(const currency::transaction& tx, const currency::blobdata& blob, currency::core& c, bool invalid_tx = false) {}  // invalid_tx is true when processing a tx, marked as invalid in a test
   virtual void before_block_pushed_to_core(const currency::block& block, const currency::blobdata& blob, currency::core& c) {}
 };

--- a/tests/unit_tests/epee_levin_protocol_handler_async.cpp
+++ b/tests/unit_tests/epee_levin_protocol_handler_async.cpp
@@ -264,7 +264,7 @@ TEST_F(positive_test_connection_to_levin_protocol_handler_calls, handler_initial
 TEST_F(positive_test_connection_to_levin_protocol_handler_calls, concurent_handler_initialization_and_destruction_is_correct)
 {
   const size_t connection_count = 10000;
-  auto create_and_destroy_connections = [this, connection_count]()
+  auto create_and_destroy_connections = [this]()
   {
     std::vector<test_connection_ptr> connections(connection_count);
     for (size_t i = 0; i < connection_count; ++i)


### PR DESCRIPTION
Well, almost all of them. I'd rather not touch the following for now:

```
zano/tests/core_tests/chaingen.cpp:1646:131: warning: lambda capture 'digits' is not used [-Wunused-lambda-capture]                                                                              
  decompose_amount_into_digits(first_blocks_reward, DEFAULT_DUST_THRESHOLD, [&digits](uint64_t chunk){ digits.insert(chunk); }, [&digits](uint64_t dust) { /* nope */ });
```

Regarding this PR, I'm curious to see how well this plays with MSVC and XCode. I'll be happy to make any adjustments as needed.