### PR TITLE
db_tests: use static zlib for build consistency

### DIFF
--- a/tests/db_tests/CMakeLists.txt
+++ b/tests/db_tests/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(db_tests db_tests.cpp)
-target_link_libraries(db_tests crypto common lmdb zlib ${Boost_LIBRARIES})
+target_link_libraries(db_tests crypto common lmdb zlibstatic ${Boost_LIBRARIES})
 


### PR DESCRIPTION
The build is still fixed but, after further review, the zlib dynamic lib
is never actually used in the zano build (sorry about that). As such, I
think there should be build-consistency until further action is taken
regarding any unnecessary dynamic dependency building.