### PR TITLE
CMake: finish removal of OpenCL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,9 +98,6 @@ endif()
 
 add_library(crypto ${CRYPTO})
 
-MESSAGE( STATUS "INCLUDING OpenCL_INCLUDE_DIRS:         " ${OpenCL_INCLUDE_DIRS} )
-include_directories( ${OpenCL_INCLUDE_DIRS} )
-
 add_library(currency_core ${CURRENCY_CORE})
 add_dependencies(currency_core version rpc ${PCH_LIB_NAME})
 ENABLE_SHARED_PCH(CURRENCY_CORE)


### PR DESCRIPTION
Officially removed in c6f1fb3b67bc143d2a035d14a1b19949dcb31bfe