### PR TITLE
CMake: add GUI convenience "bundle" 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,6 @@ cmake_gui = -D BUILD_GUI=ON
 cmake_static = -D STATIC=ON
 cmake_tests = -D BUILD_TESTS=ON
 
-gui:
-	$(eval command += $(cmake_release) $(cmake_gui))
-	$(call CMAKE,$(dir_release),$(command)) && $(MAKE)
-
 # Helper macro
 define CMAKE
   mkdir -p $1 && cd $1 && $2 ../../

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,9 +162,15 @@ if(BUILD_GUI)
   set_property(TARGET Zano PROPERTY FOLDER "prog")
   set_target_properties(Zano PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/gui/qt-daemon/Info.plist.in)
 
-  set_target_properties(Zano PROPERTIES VS_DEBUGGER_COMMAND_ARGUMENTS "--html-path=${CMAKE_CURRENT_SOURCE_DIR}/gui/qt-daemon/html")
+  set(HTML_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gui/qt-daemon/html)
+  set_target_properties(Zano PROPERTIES VS_DEBUGGER_COMMAND_ARGUMENTS "--html-path=${HTML_DIR}")
 
   set(CMAKE_AUTOMOC OFF)
+
+  # GUI convenience "bundle"
+  set(GUI_DIR ${CMAKE_CURRENT_BINARY_DIR}/gui)
+  set_target_properties(Zano PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${GUI_DIR})
+  add_custom_command(TARGET Zano POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${HTML_DIR} ${GUI_DIR}/html)
 endif()
 
 if(APPLE)


### PR DESCRIPTION
Makes #19 easier to manage.

Note: this will affect any internal GUI build scripts because the target output directory has changed (I chose this method instead of doing a pure copy, so we don't have multiple binaries).

I can change to a pure copy if needed.