### PR TITLE
Changes needed to compile with boost 1.75

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -32,372 +32,341 @@
 #include <mutex>
 #include <thread>
 
-namespace epee
-{
-  class async_stdin_reader
-  {
+namespace epee {
+class async_stdin_reader {
   public:
-    async_stdin_reader()
-      : m_run(true)
-      , m_has_read_request(false)
-      , m_read_status(state_init)
-    {
-      m_reader_thread = std::thread(std::bind(&async_stdin_reader::reader_thread_func, this));
+  async_stdin_reader()
+      : m_run(true), m_has_read_request(false), m_read_status(state_init)
+  {
+    m_reader_thread = std::thread(std::bind(&async_stdin_reader::reader_thread_func, this));
+  }
+
+  ~async_stdin_reader()
+  {
+    stop();
+  }
+
+  // Not thread safe. Only one thread can call this method at once.
+  bool get_line(std::string& line)
+  {
+    if(!start_read())
+      return false;
+
+    std::unique_lock<std::mutex> lock(m_response_mutex);
+    while(state_init == m_read_status) {
+      m_response_cv.wait(lock);
     }
 
-    ~async_stdin_reader()
-    {
-      stop();
+    bool res = false;
+    if(state_success == m_read_status) {
+      line = m_line;
+      res  = true;
     }
 
-    // Not thread safe. Only one thread can call this method at once.
-    bool get_line(std::string& line)
-    {
-      if (!start_read())
-        return false;
+    m_read_status = state_init;
 
-      std::unique_lock<std::mutex> lock(m_response_mutex);
-      while (state_init == m_read_status)
-      {
-        m_response_cv.wait(lock);
-      }
+    return res;
+  }
 
-      bool res = false;
-      if (state_success == m_read_status)
-      {
-        line = m_line;
-        res = true;
-      }
-
-      m_read_status = state_init;
-
-      return res;
-    }
-
-    void stop()
-    {
-      if (m_run)
-      {
-        m_run.store(false, std::memory_order_relaxed);
+  void stop()
+  {
+    if(m_run) {
+      m_run.store(false, std::memory_order_relaxed);
 
 #if defined(WIN32)
-        ::CloseHandle(::GetStdHandle(STD_INPUT_HANDLE));
+      ::CloseHandle(::GetStdHandle(STD_INPUT_HANDLE));
 #endif
 
-        m_request_cv.notify_one();
-        m_reader_thread.join();
-      }
-    }
-
-  private:
-    bool start_read()
-    {
-      std::unique_lock<std::mutex> lock(m_request_mutex);
-      if (!m_run.load(std::memory_order_relaxed) || m_has_read_request)
-        return false;
-
-      m_has_read_request = true;
       m_request_cv.notify_one();
+      m_reader_thread.join();
+    }
+  }
+
+  private:
+  bool start_read()
+  {
+    std::unique_lock<std::mutex> lock(m_request_mutex);
+    if(!m_run.load(std::memory_order_relaxed) || m_has_read_request)
+      return false;
+
+    m_has_read_request = true;
+    m_request_cv.notify_one();
+    return true;
+  }
+
+  bool wait_read()
+  {
+    std::unique_lock<std::mutex> lock(m_request_mutex);
+    while(m_run.load(std::memory_order_relaxed) && !m_has_read_request) {
+      m_request_cv.wait(lock);
+    }
+
+    if(m_has_read_request) {
+      m_has_read_request = false;
       return true;
     }
 
-    bool wait_read()
-    {
-      std::unique_lock<std::mutex> lock(m_request_mutex);
-      while (m_run.load(std::memory_order_relaxed) && !m_has_read_request)
-      {
-        m_request_cv.wait(lock);
-      }
+    return false;
+  }
 
-      if (m_has_read_request)
-      {
-        m_has_read_request = false;
-        return true;
-      }
-
-      return false;
-    }
-
-    bool wait_stdin_data()
-    {
+  bool wait_stdin_data()
+  {
 #if !defined(WIN32)
-      int stdin_fileno = ::fileno(stdin);
+    int stdin_fileno = ::fileno(stdin);
 
-      while (m_run.load(std::memory_order_relaxed))
-      {
-        fd_set read_set;
-        FD_ZERO(&read_set);
-        FD_SET(stdin_fileno, &read_set);
+    while(m_run.load(std::memory_order_relaxed)) {
+      fd_set read_set;
+      FD_ZERO(&read_set);
+      FD_SET(stdin_fileno, &read_set);
 
-        struct timeval tv;
-        tv.tv_sec = 0;
-        tv.tv_usec = 100 * 1000;
+      struct timeval tv;
+      tv.tv_sec  = 0;
+      tv.tv_usec = 100 * 1000;
 
-        int retval = ::select(stdin_fileno + 1, &read_set, NULL, NULL, &tv);
-        if (retval < 0)
-          return false;
-        else if (0 < retval)
-          return true;
-      }
+      int retval = ::select(stdin_fileno + 1, &read_set, NULL, NULL, &tv);
+      if(retval < 0)
+        return false;
+      else if(0 < retval)
+        return true;
+    }
 #endif
 
-      return true;
-    }
-
-    void reader_thread_func()
-    {
-      while (true)
-      {
-        if (!wait_read())
-          break;
-
-        std::string line;
-        bool read_ok = true;
-        if (wait_stdin_data())
-        {
-          if (m_run.load(std::memory_order_relaxed))
-          {
-            std::getline(std::cin, line);
-            read_ok = !std::cin.eof() && !std::cin.fail();
-          }
-        }
-        else
-        {
-          read_ok = false;
-        }
-
-        {
-          std::unique_lock<std::mutex> lock(m_response_mutex);
-          if (m_run.load(std::memory_order_relaxed))
-          {
-            m_line = std::move(line);
-            m_read_status = read_ok ? state_success : state_error;
-          }
-          else
-          {
-            m_read_status = state_cancelled;
-          }
-          m_response_cv.notify_one();
-        }
-      }
-    }
-
-    enum t_state
-    {
-      state_init,
-      state_success,
-      state_error,
-      state_cancelled
-    };
-
-  private:
-    std::thread m_reader_thread;
-    std::atomic<bool> m_run;
-
-    std::string m_line;
-    bool m_has_read_request;
-    t_state m_read_status;
-
-    std::mutex m_request_mutex;
-    std::mutex m_response_mutex;
-    std::condition_variable m_request_cv;
-    std::condition_variable m_response_cv;
-  };
-
-
-  template<class t_server>
-  bool empty_commands_handler(t_server* psrv, const std::string& command)
-  {
     return true;
   }
 
-
-  class async_console_handler
+  void reader_thread_func()
   {
+    while(true) {
+      if(!wait_read())
+        break;
+
+      std::string line;
+      bool read_ok = true;
+      if(wait_stdin_data()) {
+        if(m_run.load(std::memory_order_relaxed)) {
+          std::getline(std::cin, line);
+          read_ok = !std::cin.eof() && !std::cin.fail();
+        }
+      }
+      else {
+        read_ok = false;
+      }
+
+      {
+        std::unique_lock<std::mutex> lock(m_response_mutex);
+        if(m_run.load(std::memory_order_relaxed)) {
+          m_line        = std::move(line);
+          m_read_status = read_ok ? state_success : state_error;
+        }
+        else {
+          m_read_status = state_cancelled;
+        }
+        m_response_cv.notify_one();
+      }
+    }
+  }
+
+  enum t_state {
+    state_init,
+    state_success,
+    state_error,
+    state_cancelled
+  };
+
+  private:
+  std::thread m_reader_thread;
+  std::atomic<bool> m_run;
+
+  std::string m_line;
+  bool m_has_read_request;
+  t_state m_read_status;
+
+  std::mutex m_request_mutex;
+  std::mutex m_response_mutex;
+  std::condition_variable m_request_cv;
+  std::condition_variable m_response_cv;
+};
+
+template<class t_server>
+bool empty_commands_handler(t_server* psrv, const std::string& command)
+{
+  return true;
+}
+
+class async_console_handler {
   public:
-    async_console_handler()
-    {
-    }
+  async_console_handler()
+  {
+  }
 
-    template<class t_server, class chain_handler>
-    bool run(t_server* psrv, chain_handler ch_handler, const std::string& prompt = "#", const std::string& usage = "")
-    {
-      return run(prompt, usage, [&](const std::string& cmd) { return ch_handler(psrv, cmd); }, [&] { psrv->send_stop_signal(); });
-    }
+  template<class t_server, class chain_handler>
+  bool run(t_server* psrv, chain_handler ch_handler, const std::string& prompt = "#", const std::string& usage = "")
+  {
+    return run(
+        prompt, usage, [&](const std::string& cmd) { return ch_handler(psrv, cmd); }, [&] { psrv->send_stop_signal(); });
+  }
 
-    template<class chain_handler>
-    bool run(chain_handler ch_handler, const std::string& prompt = "#", const std::string& usage = "")
-    {
-      return run(prompt, usage, [&](const std::string& cmd) { return ch_handler(cmd); }, [] { });
-    }
+  template<class chain_handler>
+  bool run(chain_handler ch_handler, const std::string& prompt = "#", const std::string& usage = "")
+  {
+    return run(
+        prompt, usage, [&](const std::string& cmd) { return ch_handler(cmd); }, [] {});
+  }
 
-    void stop()
-    {
-      m_stdin_reader.stop();
-    }
+  void stop()
+  {
+    m_stdin_reader.stop();
+  }
 
   private:
-    template<typename t_cmd_handler, typename t_exit_handler>
-    bool run(const std::string& prompt, const std::string& usage, const t_cmd_handler& cmd_handler, const t_exit_handler& exit_handler)
-    {
-      TRY_ENTRY();
-      bool continue_handle = true;
-      while(continue_handle)
-      {
-        if (!prompt.empty())
-        {
-          epee::log_space::set_console_color(epee::log_space::console_color_yellow, true);
-          std::cout << prompt;
-          if (' ' != prompt.back())
-            std::cout << ' ';
-          epee::log_space::reset_console_color();
-          std::cout.flush();
+  template<typename t_cmd_handler, typename t_exit_handler>
+  bool run(const std::string& prompt, const std::string& usage, const t_cmd_handler& cmd_handler, const t_exit_handler& exit_handler)
+  {
+    TRY_ENTRY();
+    bool continue_handle = true;
+    while(continue_handle) {
+      if(!prompt.empty()) {
+        epee::log_space::set_console_color(epee::log_space::console_color_yellow, true);
+        std::cout << prompt;
+        if(' ' != prompt.back())
+          std::cout << ' ';
+        epee::log_space::reset_console_color();
+        std::cout.flush();
+      }
+
+      std::string command;
+      if(!m_stdin_reader.get_line(command)) {
+        LOG_PRINT("Failed to read line. Stopping...", LOG_LEVEL_0);
+        continue_handle = false;
+        break;
+      }
+      string_tools::trim(command);
+
+      LOG_PRINT_L2("Read command: " << command);
+      if(0 == command.compare("exit") || 0 == command.compare("q")) {
+        cmd_handler(command);
+        continue_handle = false;
+      }
+      else if(!command.compare(0, 7, "set_log")) {
+        //parse set_log command
+        static const std::string command_wrong_syntax = "set_log: wrong syntax, usage: set_log log_level_number | log_channel_name_1,log_channel_name_2,... 0|1";
+        std::string args                              = epee::string_tools::trim(command.substr(7));
+        if(args.empty()) {
+          std::set<std::string>& enabled_channels = epee::log_space::log_singletone::get_enabled_channels();
+          std::cout << "current log level: " << log_space::get_set_log_detalisation_level() << ", enabled channels: ";
+          for(auto& channel : enabled_channels)
+            std::cout << channel << " ";
+          std::cout << std::endl;
+          continue;
         }
 
-        std::string command;
-        if(!m_stdin_reader.get_line(command))
-        {
-          LOG_PRINT("Failed to read line. Stopping...", LOG_LEVEL_0);
-          continue_handle = false;
-          break;
-        }
-        string_tools::trim(command);
-
-        LOG_PRINT_L2("Read command: " << command);
-        if(0 == command.compare("exit") || 0 == command.compare("q"))
-        {
-          cmd_handler(command);
-          continue_handle = false;
-        }else if (!command.compare(0, 7, "set_log"))
-        {
-          //parse set_log command
-          static const std::string command_wrong_syntax = "set_log: wrong syntax, usage: set_log log_level_number | log_channel_name_1,log_channel_name_2,... 0|1";
-          std::string args = epee::string_tools::trim(command.substr(7));
-          if (args.empty())
-          {
-            std::set<std::string>& enabled_channels = epee::log_space::log_singletone::get_enabled_channels();
-            std::cout << "current log level: " << log_space::get_set_log_detalisation_level() << ", enabled channels: ";
-            for(auto& channel : enabled_channels)
-              std::cout << channel << " ";
-            std::cout << std::endl;
+        size_t args_space_pos = args.find(' ');
+        if(args_space_pos != std::string::npos) {
+          // channel enabling / disabling
+          std::string channel_str = args.substr(0, args_space_pos);
+          std::string value_str   = args.substr(args_space_pos + 1);
+          if(channel_str.empty() || value_str.empty()) {
+            std::cout << command_wrong_syntax << std::endl;
             continue;
           }
 
-          size_t args_space_pos = args.find(' ');
-          if (args_space_pos != std::string::npos)
-          {
-            // channel enabling / disabling
-            std::string channel_str = args.substr(0, args_space_pos);
-            std::string value_str = args.substr(args_space_pos + 1);
-            if (channel_str.empty() || value_str.empty())
-            {
-              std::cout << command_wrong_syntax << std::endl;
-              continue;
-            }
+          bool multi_channels = channel_str.find_first_of(",;:") != std::string::npos;
 
-            bool multi_channels = channel_str.find_first_of(",;:") != std::string::npos;
-
-            if (value_str == "1" || value_str == "e" || value_str == "y")
-              if (multi_channels)
-                epee::log_space::log_singletone::enable_channels(channel_str);
-              else
-                epee::log_space::log_singletone::enable_channel(channel_str);
+          if(value_str == "1" || value_str == "e" || value_str == "y")
+            if(multi_channels)
+              epee::log_space::log_singletone::enable_channels(channel_str);
             else
-              if (multi_channels)
-                epee::log_space::log_singletone::disable_channels(channel_str);
-              else
-                epee::log_space::log_singletone::disable_channel(channel_str);
-          }
+              epee::log_space::log_singletone::enable_channel(channel_str);
+          else if(multi_channels)
+            epee::log_space::log_singletone::disable_channels(channel_str);
           else
-          {
-            // log level set
-            uint16_t n = 0;
-            if(!string_tools::get_xtype_from_string(n, args))
-            {
-              std::cout << command_wrong_syntax << std::endl;
-              continue;
-            }
-            uint16_t previous_log_level = log_space::get_set_log_detalisation_level();
-            log_space::get_set_log_detalisation_level(true, n);
-            if (n < LOG_LEVEL_2)
-              std::cout << "log level: " << previous_log_level << " -> " << n << std::endl;
-            LOG_PRINT_L2("log level: " << previous_log_level << " -> " << n);
-          }
-
-          if (args.empty())
-          {
-            std::cout << "wrong syntax: " << command << std::endl << "use set_log n" << std::endl;
+            epee::log_space::log_singletone::disable_channel(channel_str);
+        }
+        else {
+          // log level set
+          uint16_t n = 0;
+          if(!string_tools::get_xtype_from_string(n, args)) {
+            std::cout << command_wrong_syntax << std::endl;
             continue;
           }
-        }else if (command.empty())
-        {
-          continue;
+          uint16_t previous_log_level = log_space::get_set_log_detalisation_level();
+          log_space::get_set_log_detalisation_level(true, n);
+          if(n < LOG_LEVEL_2)
+            std::cout << "log level: " << previous_log_level << " -> " << n << std::endl;
+          LOG_PRINT_L2("log level: " << previous_log_level << " -> " << n);
         }
-        else if(cmd_handler(command))
-        {
+
+        if(args.empty()) {
+          std::cout << "wrong syntax: " << command << std::endl
+                    << "use set_log n" << std::endl;
           continue;
-        } else
-        {
-          std::cout << "unknown command: " << command << std::endl;
-          std::cout << usage;
         }
       }
-      exit_handler();
-      return true;
-      CATCH_ENTRY_L0("console_handler", false);
+      else if(command.empty()) {
+        continue;
+      }
+      else if(cmd_handler(command)) {
+        continue;
+      }
+      else {
+        std::cout << "unknown command: " << command << std::endl;
+        std::cout << usage;
+      }
     }
+    exit_handler();
+    return true;
+    CATCH_ENTRY_L0("console_handler", false);
+  }
 
   private:
-    async_stdin_reader m_stdin_reader;
-  };
+  async_stdin_reader m_stdin_reader;
+};
 
+template<class t_server, class t_handler>
+bool start_default_console(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
+{
+  std::shared_ptr<async_console_handler> console_handler = std::make_shared<async_console_handler>();
+  boost::thread([=]() { console_handler->run<t_server, t_handler>(ptsrv, handlr, prompt, usage); }).detach();
+  return true;
+}
 
-  template<class t_server, class t_handler>
-  bool start_default_console(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
-  {
-    std::shared_ptr<async_console_handler> console_handler = std::make_shared<async_console_handler>();
-	boost::thread([=](){console_handler->run<t_server, t_handler>(ptsrv, handlr, prompt, usage);}).detach();
-    return true;
-  }
+template<class t_server>
+bool start_default_console(t_server* ptsrv, const std::string& prompt, const std::string& usage = "")
+{
+  return start_default_console(ptsrv, empty_commands_handler<t_server>, prompt, usage);
+}
 
-  template<class t_server>
-  bool start_default_console(t_server* ptsrv, const std::string& prompt, const std::string& usage = "")
-  {
-    return start_default_console(ptsrv, empty_commands_handler<t_server>, prompt, usage);
-  }
+template<class t_server, class t_handler>
+bool no_srv_param_adapter(t_server* ptsrv, const std::string& cmd, t_handler handlr)
+{
+  return handlr(cmd);
+}
 
-  template<class t_server, class t_handler>
-    bool no_srv_param_adapter(t_server* ptsrv, const std::string& cmd, t_handler handlr)
-    {
-      return handlr(cmd);
-    }
+template<class t_server, class t_handler>
+bool run_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
+{
+  async_console_handler console_handler;
+  return console_handler.run(ptsrv, boost::bind<bool>(no_srv_param_adapter<t_server, t_handler>, boost::placeholders::_1, boost::placeholders::_2, handlr), prompt, usage);
+}
 
-  template<class t_server, class t_handler>
-  bool run_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
-  {
-    async_console_handler console_handler;
-    return console_handler.run(ptsrv, boost::bind<bool>(no_srv_param_adapter<t_server, t_handler>, _1, _2, handlr), prompt, usage);
-  }
+template<class t_server, class t_handler>
+bool start_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
+{
+  boost::thread(boost::bind(run_default_console_handler_no_srv_param<t_server, t_handler>, ptsrv, handlr, prompt, usage));
+  return true;
+}
 
-  template<class t_server, class t_handler>
-  bool start_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
-  {
-    boost::thread( boost::bind(run_default_console_handler_no_srv_param<t_server, t_handler>, ptsrv, handlr, prompt, usage) );
-    return true;
-  }
-
-  /*template<class a>
+/*template<class a>
   bool f(int i, a l)
   {
     return true;
   }*/
-  /*
+/*
   template<class chain_handler>
   bool default_console_handler2(chain_handler ch_handler, const std::string usage)
   */
 
-
-  /*template<class t_handler>
+/*template<class t_handler>
   bool start_default_console2(t_handler handlr, const std::string& usage = "")
   {
     //std::string usage_local = usage;
@@ -408,119 +377,118 @@ namespace epee
     return true;
   }*/
 
-  /************************************************************************/
-  /*                                                                      */
-  /************************************************************************/
-  class console_handlers_binder
-  {
-    typedef boost::function<bool (const std::vector<std::string> &)> console_command_handler;
-    typedef std::map<std::string, std::pair<console_command_handler, std::string> > command_handlers_map;
-    std::unique_ptr<boost::thread> m_console_thread;
-    command_handlers_map m_command_handlers;
-    async_console_handler m_console_handler;
+/************************************************************************/
+/*                                                                      */
+/************************************************************************/
+class console_handlers_binder {
+  typedef boost::function<bool(const std::vector<std::string>&)> console_command_handler;
+  typedef std::map<std::string, std::pair<console_command_handler, std::string>> command_handlers_map;
+  std::unique_ptr<boost::thread> m_console_thread;
+  command_handlers_map m_command_handlers;
+  async_console_handler m_console_handler;
+
   public:
-    std::string get_usage()
-    {
-      std::stringstream ss;
-      size_t max_command_len = 0;
-      for(auto& x:m_command_handlers)
-        if(x.first.size() > max_command_len)
-          max_command_len = x.first.size();
+  std::string get_usage()
+  {
+    std::stringstream ss;
+    size_t max_command_len = 0;
+    for(auto& x : m_command_handlers)
+      if(x.first.size() > max_command_len)
+        max_command_len = x.first.size();
 
-      for(auto& x:m_command_handlers)
-      {
-        ss << "  " << std::left << std::setw(max_command_len + 3) << x.first << " " << x.second.second << ENDL;
-      }
-      return ss.str();
+    for(auto& x : m_command_handlers) {
+      ss << "  " << std::left << std::setw(max_command_len + 3) << x.first << " " << x.second.second << ENDL;
     }
-    void set_handler(const std::string& cmd, const console_command_handler& hndlr, const std::string& usage = "")
-    {
-      command_handlers_map::mapped_type & vt = m_command_handlers[cmd];
-      vt.first = hndlr;
-      vt.second = usage;
-    }
-    bool process_command_vec(const std::vector<std::string>& cmd)
-    {
-      if(!cmd.size())
-        return false;
-      auto it = m_command_handlers.find(cmd.front());
-      if(it == m_command_handlers.end())
-        return false;
-      std::vector<std::string> cmd_local(cmd.begin()+1, cmd.end());
-      return it->second.first(cmd_local);
-    }
+    return ss.str();
+  }
+  void set_handler(const std::string& cmd, const console_command_handler& hndlr, const std::string& usage = "")
+  {
+    command_handlers_map::mapped_type& vt = m_command_handlers[cmd];
+    vt.first                              = hndlr;
+    vt.second                             = usage;
+  }
+  bool process_command_vec(const std::vector<std::string>& cmd)
+  {
+    if(!cmd.size())
+      return false;
+    auto it = m_command_handlers.find(cmd.front());
+    if(it == m_command_handlers.end())
+      return false;
+    std::vector<std::string> cmd_local(cmd.begin() + 1, cmd.end());
+    return it->second.first(cmd_local);
+  }
 
-    bool process_command_str(const std::string& cmd)
-    {
-      std::vector<std::string> cmd_v;
-      boost::split(cmd_v,cmd,boost::is_any_of(" "), boost::token_compress_on);
-      return process_command_vec(cmd_v);
-    }
+  bool process_command_str(const std::string& cmd)
+  {
+    std::vector<std::string> cmd_v;
+    boost::split(cmd_v, cmd, boost::is_any_of(" "), boost::token_compress_on);
+    return process_command_vec(cmd_v);
+  }
 
-    /*template<class t_srv>
+  /*template<class t_srv>
     bool start_handling(t_srv& srv, const std::string& usage_string = "")
     {
       start_default_console_handler_no_srv_param(&srv, boost::bind(&console_handlers_binder::process_command_str, this, _1));
       return true;
     }*/
 
-    bool start_handling(const std::string& prompt, const std::string& usage_string = "")
-    {
-      m_console_thread.reset(new boost::thread(boost::bind(&console_handlers_binder::run_handling, this, prompt, usage_string)));
-      m_console_thread->detach();
-      return true;
-    }
+  bool start_handling(const std::string& prompt, const std::string& usage_string = "")
+  {
+    m_console_thread.reset(new boost::thread(boost::bind(&console_handlers_binder::run_handling, this, prompt, usage_string)));
+    m_console_thread->detach();
+    return true;
+  }
 
-    void stop_handling()
-    {
-      m_console_handler.stop();
-    }
+  void stop_handling()
+  {
+    m_console_handler.stop();
+  }
 
-    bool run_handling(const std::string& prompt, const std::string& usage_string)
-    {
-      return m_console_handler.run(boost::bind(&console_handlers_binder::process_command_str, this, boost::placeholders::_1), prompt, usage_string);
-    }
+  bool run_handling(const std::string& prompt, const std::string& usage_string)
+  {
+    return m_console_handler.run(boost::bind(&console_handlers_binder::process_command_str, this, boost::placeholders::_1), prompt, usage_string);
+  }
 
-    bool help(const std::vector<std::string>& /*args*/)
-    {
-      std::cout << get_usage() << ENDL;
-      return true;
-    }
-    /*template<class t_srv>
+  bool help(const std::vector<std::string>& /*args*/)
+  {
+    std::cout << get_usage() << ENDL;
+    return true;
+  }
+  /*template<class t_srv>
     bool run_handling(t_srv& srv, const std::string& usage_string)
     {
       return run_default_console_handler_no_srv_param(&srv, boost::bind<bool>(&console_handlers_binder::process_command_str, this, _1), usage_string);
     }*/
-  };
+};
 
-  /* work around because of broken boost bind */
-  template<class t_server>
-  class srv_console_handlers_binder: public console_handlers_binder
+/* work around because of broken boost bind */
+template<class t_server>
+class srv_console_handlers_binder : public console_handlers_binder {
+  bool process_command_str(t_server* /*psrv*/, const std::string& cmd)
   {
-    bool process_command_str(t_server* /*psrv*/, const std::string& cmd)
-    {
-      return console_handlers_binder::process_command_str(cmd);
-    }
+    return console_handlers_binder::process_command_str(cmd);
+  }
+
   public:
-    bool start_handling(t_server* psrv, const std::string& prompt, const std::string& usage_string = "")
-    {
-      boost::thread(boost::bind(&srv_console_handlers_binder<t_server>::run_handling, this, psrv, prompt, usage_string)).detach();
-      return true;
-    }
+  bool start_handling(t_server* psrv, const std::string& prompt, const std::string& usage_string = "")
+  {
+    boost::thread(boost::bind(&srv_console_handlers_binder<t_server>::run_handling, this, psrv, prompt, usage_string)).detach();
+    return true;
+  }
 
-    bool run_handling(t_server* psrv, const std::string& prompt, const std::string& usage_string)
-    {
-      return m_console_handler.run(psrv, boost::bind(&srv_console_handlers_binder<t_server>::process_command_str, this, _1, _2), prompt, usage_string);
-    }
+  bool run_handling(t_server* psrv, const std::string& prompt, const std::string& usage_string)
+  {
+    return m_console_handler.run(psrv, boost::bind(&srv_console_handlers_binder<t_server>::process_command_str, this, boost::placeholders::_1, boost::placeholders::_2), prompt, usage_string);
+  }
 
-    void stop_handling()
-    {
-      m_console_handler.stop();
-    }
+  void stop_handling()
+  {
+    m_console_handler.stop();
+  }
 
-    //--------------------------------------------------------------------------------
+  //--------------------------------------------------------------------------------
 
   private:
-    async_console_handler m_console_handler;
-  };
-}
+  async_console_handler m_console_handler;
+};
+}  // namespace epee

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -474,8 +474,10 @@ bool boosted_tcp_server<t_protocol_handler>::init_server(uint32_t port, const st
   CATCH_ENTRY_L0("boosted_tcp_server<t_protocol_handler>::init_server", false);
 }
 //-----------------------------------------------------------------------------
+// clang-format off
 PUSH_GCC_WARNINGS
 DISABLE_GCC_WARNING(maybe-uninitialized)
+// clang-format on
 template<class t_protocol_handler>
 bool boosted_tcp_server<t_protocol_handler>::init_server(const std::string port, const std::string& address)
 {
@@ -685,7 +687,7 @@ bool boosted_tcp_server<t_protocol_handler>::connect(const std::string& adr, con
     shared_context->cond.notify_one();
   };
 
-  sock_.async_connect(remote_endpoint, boost::bind<void>(connect_callback, _1, local_shared_context));
+  sock_.async_connect(remote_endpoint, boost::bind<void>(connect_callback, boost::placeholders::_1, local_shared_context));
   while(local_shared_context->ec == boost::asio::error::would_block) {
     bool r = false;
     try {

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2019, anonimal, <anonimal@zano.org>
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -12,7 +12,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -23,7 +23,7 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 #pragma once
 
@@ -31,101 +31,92 @@
 #include <boost/utility/value_init.hpp>
 #include "net/levin_base.h"
 
-namespace epee
+namespace epee {
+namespace net_utils {
+template<class t_arg, class t_result, class t_transport>
+bool invoke_remote_command2(int command, const t_arg& out_struct, t_result& result_struct, t_transport& transport)
 {
-  namespace net_utils
-  {
-    template<class t_arg, class t_result, class t_transport>
-    bool invoke_remote_command2(int command, const t_arg& out_struct, t_result& result_struct, t_transport& transport)
-    {
-      if(!transport.is_connected())
-        return false;
+  if(!transport.is_connected())
+    return false;
 
-      serialization::portable_storage stg;
-      out_struct.store(stg);
-      std::string buff_to_send, buff_to_recv;
-      stg.store_to_binary(buff_to_send);
-      int res = 0;
-      TRY_ENTRY()
-      res = transport.invoke(command, buff_to_send, buff_to_recv);
-      CATCH_ENTRY2(false)
-      if( res <=0 )
-      {
-        LOG_PRINT_RED("Failed to invoke command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")", LOG_LEVEL_1);
-        return false;
-      }
-      serialization::portable_storage stg_ret;
-      if(!stg_ret.load_from_binary(buff_to_recv))
-      {
-        LOG_ERROR("Failed to load_from_binary on command " << command);
-        return false;
-      }
-      result_struct.load(stg_ret);
-      return true;
-    }
+  serialization::portable_storage stg;
+  out_struct.store(stg);
+  std::string buff_to_send, buff_to_recv;
+  stg.store_to_binary(buff_to_send);
+  int res = 0;
+  TRY_ENTRY()
+  res = transport.invoke(command, buff_to_send, buff_to_recv);
+  CATCH_ENTRY2(false)
+  if(res <= 0) {
+    LOG_PRINT_RED("Failed to invoke command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")", LOG_LEVEL_1);
+    return false;
+  }
+  serialization::portable_storage stg_ret;
+  if(!stg_ret.load_from_binary(buff_to_recv)) {
+    LOG_ERROR("Failed to load_from_binary on command " << command);
+    return false;
+  }
+  result_struct.load(stg_ret);
+  return true;
+}
 
-    template<class t_arg, class t_transport>
-    bool notify_remote_command2(int command, const t_arg& out_struct, t_transport& transport)
-    {
-      if(!transport.is_connected())
-        return false;
+template<class t_arg, class t_transport>
+bool notify_remote_command2(int command, const t_arg& out_struct, t_transport& transport)
+{
+  if(!transport.is_connected())
+    return false;
 
-      serialization::portable_storage stg;
-      out_struct.store(&stg);
-      std::string buff_to_send;
-      stg.store_to_binary(buff_to_send);
-      int res = 0;
-      TRY_ENTRY()
-      res = transport.notify(command, buff_to_send);
-      CATCH_ENTRY2(false)
-      if(res <=0 )
-      {
-        LOG_ERROR("Failed to notify command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")");
-        return false;
-      }
-      return true;
-    }
+  serialization::portable_storage stg;
+  out_struct.store(&stg);
+  std::string buff_to_send;
+  stg.store_to_binary(buff_to_send);
+  int res = 0;
+  TRY_ENTRY()
+  res = transport.notify(command, buff_to_send);
+  CATCH_ENTRY2(false)
+  if(res <= 0) {
+    LOG_ERROR("Failed to notify command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")");
+    return false;
+  }
+  return true;
+}
 
-    template<class t_arg, class t_result, class t_transport>
-    bool invoke_remote_command2(boost::uuids::uuid conn_id, int command, const t_arg& out_struct, t_result& result_struct, t_transport& transport)
-    {
+template<class t_arg, class t_result, class t_transport>
+bool invoke_remote_command2(boost::uuids::uuid conn_id, int command, const t_arg& out_struct, t_result& result_struct, t_transport& transport)
+{
+  typename serialization::portable_storage stg;
+  out_struct.store(stg);
+  std::string buff_to_send, buff_to_recv;
+  stg.store_to_binary(buff_to_send);
+  int res = 0;
+  TRY_ENTRY()
+  res = transport.invoke(command, buff_to_send, buff_to_recv, conn_id);
+  CATCH_ENTRY2(false)
+  if(res <= 0) {
+    LOG_PRINT_L1("Failed to invoke command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")");
+    return false;
+  }
+  typename serialization::portable_storage stg_ret;
+  if(!stg_ret.load_from_binary(buff_to_recv)) {
+    LOG_ERROR("Failed to load_from_binary on command " << command);
+    return false;
+  }
+  result_struct.load(stg_ret);
 
-      typename serialization::portable_storage stg;
-      out_struct.store(stg);
-      std::string buff_to_send, buff_to_recv;
-      stg.store_to_binary(buff_to_send);
-      int res = 0;
-      TRY_ENTRY()
-      res = transport.invoke(command, buff_to_send, buff_to_recv, conn_id);
-      CATCH_ENTRY2(false)
-      if( res <=0 )
-      {
-        LOG_PRINT_L1("Failed to invoke command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")");
-        return false;
-      }
-      typename serialization::portable_storage stg_ret;
-      if(!stg_ret.load_from_binary(buff_to_recv))
-      {
-        LOG_ERROR("Failed to load_from_binary on command " << command);
-        return false;
-      }
-      result_struct.load(stg_ret);
+  return true;
+}
 
-      return true;
-    }
-
-    template<class t_result, class t_arg, class callback_t, class t_transport>
-    bool async_invoke_remote_command2(boost::uuids::uuid conn_id, int command, const t_arg& out_struct, t_transport& transport, const callback_t& cb, size_t inv_timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
-    {
-      typename serialization::portable_storage stg;
-      const_cast<t_arg&>(out_struct).store(stg);//TODO: add true const support to searilzation
-      std::string buff_to_send, buff_to_recv;
-      stg.store_to_binary(buff_to_send);
-      int res = transport.invoke_async(command, buff_to_send, conn_id, [cb, command](int code, const std::string& buff, typename t_transport::connection_context& context)->bool 
-      {
+template<class t_result, class t_arg, class callback_t, class t_transport>
+bool async_invoke_remote_command2(boost::uuids::uuid conn_id, int command, const t_arg& out_struct, t_transport& transport, const callback_t& cb, size_t inv_timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
+{
+  typename serialization::portable_storage stg;
+  const_cast<t_arg&>(out_struct).store(stg);  //TODO: add true const support to searilzation
+  std::string buff_to_send, buff_to_recv;
+  stg.store_to_binary(buff_to_send);
+  int res = transport.invoke_async(
+      command, buff_to_send, conn_id, [cb, command](int code, const std::string& buff, typename t_transport::connection_context& context) -> bool {
         t_result result_struct = AUTO_VAL_INIT(result_struct);
-        if( code <=0 )
-        {
+        if(code <= 0) {
           LOG_PRINT_L2("BACKTRACE: " << ENDL << epee::misc_utils::get_callstack());
           LOG_PRINT_L1("Failed to invoke command " << command << " return code " << code << "(" << epee::levin::get_err_descr(code) << ")context:" << print_connection_context(context));
           TRY_ENTRY()
@@ -134,8 +125,7 @@ namespace epee
           return false;
         }
         serialization::portable_storage stg_ret;
-        if(!stg_ret.load_from_binary(buff))
-        {
+        if(!stg_ret.load_from_binary(buff)) {
           LOG_ERROR("Failed to load_from_binary on command " << command);
           TRY_ENTRY();
           cb(LEVIN_ERROR_FORMAT, result_struct, context);
@@ -147,167 +137,168 @@ namespace epee
         cb(code, result_struct, context);
         CATCH_ENTRY2(true)
         return true;
-      }, inv_timeout);
-      if( res <=0 )
-      {
-        LOG_PRINT_L2("BACKTRACE: " << ENDL << epee::misc_utils::get_callstack());
-        LOG_PRINT_L1("Failed to invoke command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ") conn_id=" << conn_id);
-        return false;
-      }
-      return true;
-    }
-
-    template<class t_arg, class t_transport>
-    bool notify_remote_command2(boost::uuids::uuid conn_id, int command, const t_arg& out_struct, t_transport& transport)
-    {
-
-      serialization::portable_storage stg;
-      out_struct.store(stg);
-      std::string buff_to_send, buff_to_recv;
-      stg.store_to_binary(buff_to_send);
-      int res = LEVIN_ERROR_UNKNOWN_ERROR;
-      TRY_ENTRY()
-      res = transport.notify(command, buff_to_send, conn_id);
-      CATCH_ENTRY2(false)
-      if(res <=0 )
-      {
-        LOG_PRINT_RED_L0("Failed to notify command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")");
-        return false;
-      }
-      return true;
-    }
-    //----------------------------------------------------------------------------------------------------
-    //----------------------------------------------------------------------------------------------------
-    template<class t_owner, class t_in_type, class t_out_type, class t_context, class callback_t>
-    int buff_to_t_adapter(int command, const std::string& in_buff, std::string& buff_out, callback_t cb, t_context& context )
-    {
-      serialization::portable_storage strg;
-      if(!strg.load_from_binary(in_buff))
-      {
-        LOG_ERROR("Failed to load_from_binary in command " << command);
-        return LEVIN_ERROR_FORMAT;
-      }
-      boost::value_initialized<t_in_type> in_struct;
-      boost::value_initialized<t_out_type> out_struct;
-
-      static_cast<t_in_type&>(in_struct).load(strg);
-      int res = LEVIN_ERROR_UNKNOWN_ERROR;
-      TRY_ENTRY()
-      res = cb(command, static_cast<t_in_type&>(in_struct), static_cast<t_out_type&>(out_struct), context);
-      CATCH_ENTRY2(LEVIN_ERROR_EXCEPTION)
-      serialization::portable_storage strg_out;
-      static_cast<t_out_type&>(out_struct).store(strg_out);
-
-      if(!strg_out.store_to_binary(buff_out))
-      {
-        LOG_ERROR("Failed to store_to_binary in command" << command);
-        return LEVIN_ERROR_INTERNAL;
-      }
-
-      return res;
-    };
-
-    template<class t_owner, class t_in_type, class t_context, class callback_t>
-    int buff_to_t_adapter(t_owner* powner, int command, const std::string& in_buff, callback_t cb, t_context& context)
-    {
-      serialization::portable_storage strg;
-      if(!strg.load_from_binary(in_buff))
-      {
-        LOG_ERROR("Failed to load_from_binary in notify " << command);
-        return LEVIN_ERROR_FORMAT;
-      }
-      boost::value_initialized<t_in_type> in_struct;
-      static_cast<t_in_type&>(in_struct).load(strg);
-      int res = LEVIN_ERROR_UNKNOWN_ERROR;
-      TRY_ENTRY()
-      res = cb(command, in_struct, context);
-      CATCH_ENTRY2(LEVIN_ERROR_EXCEPTION)
-      return res;
-    }; 
-
-#define CHAIN_LEVIN_INVOKE_MAP2(context_type) \
-  int invoke(int command, const std::string& in_buff, std::string& buff_out, context_type& context) \
-  { \
-  bool handled = false; \
-  return handle_invoke_map(false, command, in_buff, buff_out, context, handled); \
-  } 
-
-#define CHAIN_LEVIN_NOTIFY_MAP2(context_type) \
-  int notify(int command, const std::string& in_buff, context_type& context) \
-  { \
-  bool handled = false; std::string fake_str;\
-  return handle_invoke_map(true, command, in_buff, fake_str, context, handled); \
-  } 
-
-
-#define CHAIN_LEVIN_INVOKE_MAP() \
-  int invoke(int command, const std::string& in_buff, std::string& buff_out, epee::net_utils::connection_context_base& context) \
-  { \
-  bool handled = false; \
-  return handle_invoke_map(false, command, in_buff, buff_out, context, handled); \
-  } 
-
-#define CHAIN_LEVIN_NOTIFY_MAP() \
-  int notify(int command, const std::string& in_buff, epee::net_utils::connection_context_base& context) \
-  { \
-  bool handled = false; std::string fake_str;\
-  return handle_invoke_map(true, command, in_buff, fake_str, context, handled); \
-  } 
-
-#define CHAIN_LEVIN_NOTIFY_STUB() \
-  int notify(int command, const std::string& in_buff, epee::net_utils::connection_context_base& context) \
-  { \
-  return -1; \
-  } 
-
-#define BEGIN_INVOKE_MAP2(owner_type) \
-  template <class t_context> int handle_invoke_map(bool is_notify, int command, const std::string& in_buff, std::string& buff_out, t_context& context, bool& handled) \
-  { \
-  typedef owner_type internal_owner_type_name;
-
-#define HANDLE_INVOKE2(command_id, func, type_name_in, typename_out) \
-  if(!is_notify && command_id == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in, typename_out>(this, command, in_buff, buff_out, boost::bind(func, this, _1, _2, _3, _4), context);}
-
-#define HANDLE_INVOKE_T2(COMMAND, func) \
-  if(!is_notify && COMMAND::ID == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename COMMAND::request, typename COMMAND::response>(command, in_buff, buff_out, boost::bind(func, this, _1, _2, _3, _4), context);}
-
-
-#define HANDLE_NOTIFY2(command_id, func, type_name_in) \
-  if(is_notify && command_id == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in>(this, command, in_buff, boost::bind(func, this, _1, _2, _3), context);}
-
-#define HANDLE_NOTIFY_T2(NOTIFY, func) \
-  if(is_notify && NOTIFY::ID == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename NOTIFY::request>(this, command, in_buff, boost::bind(func, this, _1, _2, _3), context);}
-
-
-#define CHAIN_INVOKE_MAP2(func) \
-  { \
-  int res = func(is_notify, command, in_buff, buff_out, context, handled); \
-  if(handled) \
-  return res; \
+      },
+      inv_timeout);
+  if(res <= 0) {
+    LOG_PRINT_L2("BACKTRACE: " << ENDL << epee::misc_utils::get_callstack());
+    LOG_PRINT_L1("Failed to invoke command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ") conn_id=" << conn_id);
+    return false;
   }
-
-#define CHAIN_INVOKE_MAP_TO_OBJ2(obj) \
-  { \
-  int res = obj.handle_invoke_map(is_notify, command, in_buff, buff_out, context, handled); \
-  if(handled) \
-  return res; \
-  }
-
-#define CHAIN_INVOKE_MAP_TO_OBJ_FORCE_CONTEXT(obj, context_type) \
-  { \
-  int res = obj.handle_invoke_map(is_notify, command, in_buff, buff_out, static_cast<context_type>(context), handled); \
-  if(handled) return res; \
-  }
-
-
-#define END_INVOKE_MAP2() \
-  LOG_ERROR("Unkonown command:" << command); \
-  return LEVIN_ERROR_CONNECTION_HANDLER_NOT_DEFINED; \
-  }
-  }
+  return true;
 }
 
+template<class t_arg, class t_transport>
+bool notify_remote_command2(boost::uuids::uuid conn_id, int command, const t_arg& out_struct, t_transport& transport)
+{
+  serialization::portable_storage stg;
+  out_struct.store(stg);
+  std::string buff_to_send, buff_to_recv;
+  stg.store_to_binary(buff_to_send);
+  int res = LEVIN_ERROR_UNKNOWN_ERROR;
+  TRY_ENTRY()
+  res = transport.notify(command, buff_to_send, conn_id);
+  CATCH_ENTRY2(false)
+  if(res <= 0) {
+    LOG_PRINT_RED_L0("Failed to notify command " << command << " return code " << res << "(" << epee::levin::get_err_descr(res) << ")");
+    return false;
+  }
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------
+template<class t_owner, class t_in_type, class t_out_type, class t_context, class callback_t>
+int buff_to_t_adapter(int command, const std::string& in_buff, std::string& buff_out, callback_t cb, t_context& context)
+{
+  serialization::portable_storage strg;
+  if(!strg.load_from_binary(in_buff)) {
+    LOG_ERROR("Failed to load_from_binary in command " << command);
+    return LEVIN_ERROR_FORMAT;
+  }
+  boost::value_initialized<t_in_type> in_struct;
+  boost::value_initialized<t_out_type> out_struct;
+
+  static_cast<t_in_type&>(in_struct).load(strg);
+  int res = LEVIN_ERROR_UNKNOWN_ERROR;
+  TRY_ENTRY()
+  res = cb(command, static_cast<t_in_type&>(in_struct), static_cast<t_out_type&>(out_struct), context);
+  CATCH_ENTRY2(LEVIN_ERROR_EXCEPTION)
+  serialization::portable_storage strg_out;
+  static_cast<t_out_type&>(out_struct).store(strg_out);
+
+  if(!strg_out.store_to_binary(buff_out)) {
+    LOG_ERROR("Failed to store_to_binary in command" << command);
+    return LEVIN_ERROR_INTERNAL;
+  }
+
+  return res;
+};
+
+template<class t_owner, class t_in_type, class t_context, class callback_t>
+int buff_to_t_adapter(t_owner* powner, int command, const std::string& in_buff, callback_t cb, t_context& context)
+{
+  serialization::portable_storage strg;
+  if(!strg.load_from_binary(in_buff)) {
+    LOG_ERROR("Failed to load_from_binary in notify " << command);
+    return LEVIN_ERROR_FORMAT;
+  }
+  boost::value_initialized<t_in_type> in_struct;
+  static_cast<t_in_type&>(in_struct).load(strg);
+  int res = LEVIN_ERROR_UNKNOWN_ERROR;
+  TRY_ENTRY()
+  res = cb(command, in_struct, context);
+  CATCH_ENTRY2(LEVIN_ERROR_EXCEPTION)
+  return res;
+};
+
+#define CHAIN_LEVIN_INVOKE_MAP2(context_type)                                                       \
+  int invoke(int command, const std::string& in_buff, std::string& buff_out, context_type& context) \
+  {                                                                                                 \
+    bool handled = false;                                                                           \
+    return handle_invoke_map(false, command, in_buff, buff_out, context, handled);                  \
+  }
+
+#define CHAIN_LEVIN_NOTIFY_MAP2(context_type)                                     \
+  int notify(int command, const std::string& in_buff, context_type& context)      \
+  {                                                                               \
+    bool handled = false;                                                         \
+    std::string fake_str;                                                         \
+    return handle_invoke_map(true, command, in_buff, fake_str, context, handled); \
+  }
+
+#define CHAIN_LEVIN_INVOKE_MAP()                                                                                                \
+  int invoke(int command, const std::string& in_buff, std::string& buff_out, epee::net_utils::connection_context_base& context) \
+  {                                                                                                                             \
+    bool handled = false;                                                                                                       \
+    return handle_invoke_map(false, command, in_buff, buff_out, context, handled);                                              \
+  }
+
+#define CHAIN_LEVIN_NOTIFY_MAP()                                                                         \
+  int notify(int command, const std::string& in_buff, epee::net_utils::connection_context_base& context) \
+  {                                                                                                      \
+    bool handled = false;                                                                                \
+    std::string fake_str;                                                                                \
+    return handle_invoke_map(true, command, in_buff, fake_str, context, handled);                        \
+  }
+
+#define CHAIN_LEVIN_NOTIFY_STUB()                                                                        \
+  int notify(int command, const std::string& in_buff, epee::net_utils::connection_context_base& context) \
+  {                                                                                                      \
+    return -1;                                                                                           \
+  }
+
+#define BEGIN_INVOKE_MAP2(owner_type)                                                                                                      \
+  template<class t_context>                                                                                                                \
+  int handle_invoke_map(bool is_notify, int command, const std::string& in_buff, std::string& buff_out, t_context& context, bool& handled) \
+  {                                                                                                                                        \
+    typedef owner_type internal_owner_type_name;
+
+#define HANDLE_INVOKE2(command_id, func, type_name_in, typename_out)                                                                                                                     \
+  if(!is_notify && command_id == command) {                                                                                                                                              \
+    handled = true;                                                                                                                                                                      \
+    return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in, typename_out>(this, command, in_buff, buff_out, boost::bind(func, this, _1, _2, _3, _4), context); \
+  }
+
+#define HANDLE_INVOKE_T2(COMMAND, func)                                                                                                                                                                       \
+  if(!is_notify && COMMAND::ID == command) {                                                                                                                                                                  \
+    handled = true;                                                                                                                                                                                           \
+    return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename COMMAND::request, typename COMMAND::response>(command, in_buff, buff_out, boost::bind(func, this, _1, _2, _3, _4), context); \
+  }
+
+#define HANDLE_NOTIFY2(command_id, func, type_name_in)                                                                                                       \
+  if(is_notify && command_id == command) {                                                                                                                   \
+    handled = true;                                                                                                                                          \
+    return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in>(this, command, in_buff, boost::bind(func, this, _1, _2, _3), context); \
+  }
+
+#define HANDLE_NOTIFY_T2(NOTIFY, func)                                                                                                                                                                                                  \
+  if(is_notify && NOTIFY::ID == command) {                                                                                                                                                                                              \
+    handled = true;                                                                                                                                                                                                                     \
+    return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename NOTIFY::request>(this, command, in_buff, boost::bind(func, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3), context); \
+  }
+
+#define CHAIN_INVOKE_MAP2(func)                                              \
+  {                                                                          \
+    int res = func(is_notify, command, in_buff, buff_out, context, handled); \
+    if(handled)                                                              \
+      return res;                                                            \
+  }
+
+#define CHAIN_INVOKE_MAP_TO_OBJ2(obj)                                                         \
+  {                                                                                           \
+    int res = obj.handle_invoke_map(is_notify, command, in_buff, buff_out, context, handled); \
+    if(handled)                                                                               \
+      return res;                                                                             \
+  }
+
+#define CHAIN_INVOKE_MAP_TO_OBJ_FORCE_CONTEXT(obj, context_type)                                                         \
+  {                                                                                                                      \
+    int res = obj.handle_invoke_map(is_notify, command, in_buff, buff_out, static_cast<context_type>(context), handled); \
+    if(handled) return res;                                                                                              \
+  }
+
+#define END_INVOKE_MAP2()                            \
+  LOG_ERROR("Unkonown command:" << command);         \
+  return LEVIN_ERROR_CONNECTION_HANDLER_NOT_DEFINED; \
+  }
+}  // namespace net_utils
+}  // namespace epee

--- a/src/common/ntp.cpp
+++ b/src/common/ntp.cpp
@@ -13,7 +13,7 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/array.hpp>
 #include <epee/include/misc_log_ex.h>
@@ -22,6 +22,7 @@
 
 using boost::asio::deadline_timer;
 using boost::asio::ip::udp;
+using namespace boost::placeholders;
 
 //----------------------------------------------------------------------
 
@@ -32,7 +33,7 @@ using boost::asio::ip::udp;
 // client object:
 //
 //  +----------------+
-//  |                |     
+//  |                |
 //  | check_deadline |<---+
 //  |                |    |
 //  +----------------+    | async_wait()
@@ -58,15 +59,13 @@ using boost::asio::ip::udp;
 // The client object runs the io_service to block thread execution until the
 // actor completes.
 //
-namespace
-{
-class udp_blocking_client
-{
-public:
+namespace {
+class udp_blocking_client {
+  public:
   udp_blocking_client(const udp::endpoint& listen_endpoint, udp::socket& socket, boost::asio::io_service& io_service)
-    : socket_(socket),
-      io_service_(io_service),
-      deadline_(io_service)
+      : socket_(socket),
+        io_service_(io_service),
+        deadline_(io_service)
   {
     // No deadline is required until the first socket operation is started. We
     // set the deadline to positive infinity so that the actor takes no action
@@ -78,7 +77,7 @@ public:
   }
 
   std::size_t receive(const boost::asio::mutable_buffer& buffer,
-      boost::posix_time::time_duration timeout, boost::system::error_code& ec)
+                      boost::posix_time::time_duration timeout, boost::system::error_code& ec)
   {
     // Set a deadline for the asynchronous operation.
     deadline_.expires_from_now(timeout);
@@ -88,28 +87,29 @@ public:
     // operation is incomplete. Asio guarantees that its asynchronous
     // operations will never fail with would_block, so any other value in
     // ec indicates completion.
-    ec = boost::asio::error::would_block;
+    ec                 = boost::asio::error::would_block;
     std::size_t length = 0;
 
     // Start the asynchronous operation itself. The handle_receive function
     // used as a callback will update the ec and length variables.
     socket_.async_receive(boost::asio::buffer(buffer),
-        boost::bind(&udp_blocking_client::handle_receive, _1, _2, &ec, &length));
+                          boost::bind(&udp_blocking_client::handle_receive, _1, _2, &ec, &length));
 
     // Block until the asynchronous operation has completed.
-    do io_service_.run_one(); while (ec == boost::asio::error::would_block);
+    do
+      io_service_.run_one();
+    while(ec == boost::asio::error::would_block);
 
     return length;
   }
 
-private:
+  private:
   void check_deadline()
   {
     // Check whether the deadline has passed. We compare the deadline against
     // the current time since a new asynchronous operation may have moved the
     // deadline before this actor had a chance to run.
-    if (deadline_.expires_at() <= deadline_timer::traits_type::now())
-    {
+    if(deadline_.expires_at() <= deadline_timer::traits_type::now()) {
       // The deadline has passed. The outstanding asynchronous operation needs
       // to be cancelled so that the blocked receive() function will return.
       //
@@ -131,135 +131,120 @@ private:
       const boost::system::error_code& ec, std::size_t length,
       boost::system::error_code* out_ec, std::size_t* out_length)
   {
-    *out_ec = ec;
+    *out_ec     = ec;
     *out_length = length;
   }
 
-private:
+  private:
   boost::asio::io_service& io_service_;
   udp::socket& socket_;
   deadline_timer deadline_;
 };
 
-
 #pragma pack(push, 1)
-struct ntp_packet
-{
+struct ntp_packet {
+  uint8_t li_vn_mode;  // Eight bits. li, vn, and mode.
+                       // li.   Two bits.   Leap indicator.
+                       // vn.   Three bits. Version number of the protocol.
+                       // mode. Three bits. Client will pick mode 3 for client.
 
-  uint8_t li_vn_mode;      // Eight bits. li, vn, and mode.
-                           // li.   Two bits.   Leap indicator.
-                           // vn.   Three bits. Version number of the protocol.
-                           // mode. Three bits. Client will pick mode 3 for client.
+  uint8_t stratum;    // Eight bits. Stratum level of the local clock.
+  uint8_t poll;       // Eight bits. Maximum interval between successive messages.
+  uint8_t precision;  // Eight bits. Precision of the local clock.
 
-  uint8_t stratum;         // Eight bits. Stratum level of the local clock.
-  uint8_t poll;            // Eight bits. Maximum interval between successive messages.
-  uint8_t precision;       // Eight bits. Precision of the local clock.
+  uint32_t rootDelay;       // 32 bits. Total round trip delay time.
+  uint32_t rootDispersion;  // 32 bits. Max error aloud from primary clock source.
+  uint32_t refId;           // 32 bits. Reference clock identifier.
 
-  uint32_t rootDelay;      // 32 bits. Total round trip delay time.
-  uint32_t rootDispersion; // 32 bits. Max error aloud from primary clock source.
-  uint32_t refId;          // 32 bits. Reference clock identifier.
+  uint32_t refTm_s;  // 32 bits. Reference time-stamp seconds.
+  uint32_t refTm_f;  // 32 bits. Reference time-stamp fraction of a second.
 
-  uint32_t refTm_s;        // 32 bits. Reference time-stamp seconds.
-  uint32_t refTm_f;        // 32 bits. Reference time-stamp fraction of a second.
+  uint64_t orig_tm;  // 64 bits. Originate time-stamp (set by client)
 
-  uint64_t orig_tm;        // 64 bits. Originate time-stamp (set by client)
+  uint32_t rxTm_s;  // 32 bits. Received time-stamp seconds.
+  uint32_t rxTm_f;  // 32 bits. Received time-stamp fraction of a second.
 
-  uint32_t rxTm_s;         // 32 bits. Received time-stamp seconds.
-  uint32_t rxTm_f;         // 32 bits. Received time-stamp fraction of a second.
+  uint32_t txTm_s;  // 32 bits and the most important field the client cares about. Transmit time-stamp seconds.
+  uint32_t txTm_f;  // 32 bits. Transmit time-stamp fraction of a second.
 
-  uint32_t txTm_s;         // 32 bits and the most important field the client cares about. Transmit time-stamp seconds.
-  uint32_t txTm_f;         // 32 bits. Transmit time-stamp fraction of a second.
-
-};                         // Total: 384 bits or 48 bytes.
+};  // Total: 384 bits or 48 bytes.
 #pragma pack(pop)
 
 static_assert(sizeof(ntp_packet) == 48, "ntp_packet has invalid size");
 
-} // namespace
+}  // namespace
 
-
-namespace tools
+namespace tools {
+int64_t get_ntp_time(const std::string& host_name, size_t timeout_sec)
 {
-  int64_t get_ntp_time(const std::string& host_name, size_t timeout_sec)
-  {
-    try
-    {
-      boost::asio::io_service io_service;
-      boost::asio::ip::udp::resolver resolver(io_service);
-      boost::asio::ip::udp::resolver::query query(boost::asio::ip::udp::v4(), host_name, "ntp");
-      boost::asio::ip::udp::endpoint receiver_endpoint = *resolver.resolve(query);
-      boost::asio::ip::udp::socket socket(io_service);
-      socket.open(boost::asio::ip::udp::v4());
+  try {
+    boost::asio::io_service io_service;
+    boost::asio::ip::udp::resolver resolver(io_service);
+    boost::asio::ip::udp::resolver::query query(boost::asio::ip::udp::v4(), host_name, "ntp");
+    boost::asio::ip::udp::endpoint receiver_endpoint = *resolver.resolve(query);
+    boost::asio::ip::udp::socket socket(io_service);
+    socket.open(boost::asio::ip::udp::v4());
 
-      ntp_packet packet_sent = AUTO_VAL_INIT(packet_sent);
-      packet_sent.li_vn_mode = 0x1b;
-      auto packet_sent_time = std::chrono::high_resolution_clock::now();
-      socket.send_to(boost::asio::buffer(&packet_sent, sizeof packet_sent), receiver_endpoint);
+    ntp_packet packet_sent = AUTO_VAL_INIT(packet_sent);
+    packet_sent.li_vn_mode = 0x1b;
+    auto packet_sent_time  = std::chrono::high_resolution_clock::now();
+    socket.send_to(boost::asio::buffer(&packet_sent, sizeof packet_sent), receiver_endpoint);
 
-      ntp_packet packet_received = AUTO_VAL_INIT(packet_received);
-      boost::asio::ip::udp::endpoint sender_endpoint;
+    ntp_packet packet_received = AUTO_VAL_INIT(packet_received);
+    boost::asio::ip::udp::endpoint sender_endpoint;
 
-      udp_blocking_client ubc(sender_endpoint, socket, io_service);
-      boost::system::error_code ec;
-      ubc.receive(boost::asio::buffer(&packet_received, sizeof packet_received), boost::posix_time::seconds(static_cast<long>(timeout_sec)), ec);
-      if (ec)
-      {
-        LOG_PRINT_L3("NTP: get_ntp_time(" << host_name << "): boost error: " << ec.message());
-        return 0;
-      }
-
-      auto packet_received_time = std::chrono::high_resolution_clock::now();
-      int64_t roundtrip_mcs = std::chrono::duration_cast<std::chrono::microseconds>(packet_received_time - packet_sent_time).count();
-      uint64_t roundtrip_s = roundtrip_mcs > 2000000 ? roundtrip_mcs / 2000000 : 0;
-
-      time_t ntp_time = ntohl(packet_received.txTm_s);
-      if (ntp_time <= 2208988800U)
-      {
-        LOG_PRINT_L3("NTP: get_ntp_time(" << host_name << "): wrong txTm_s: " << packet_received.txTm_s);
-        return 0;
-      }
-      // LOG_PRINT_L2("NTP: get_ntp_time(" << host_name << "): RAW time received: " << ntp_time << ", refTm_s: " << ntohl(packet_received.refTm_s) << ", stratum: " << packet_received.stratum << ", round: " << roundtrip_mcs);
-      ntp_time -= 2208988800U;  // Unix time starts from 01/01/1970 == 2208988800U
-      ntp_time += roundtrip_s;
-      return ntp_time;
-    }
-    catch (const std::exception& e)
-    {
-      LOG_PRINT_L2("NTP: get_ntp_time(" << host_name << "): exception: " << e.what());
+    udp_blocking_client ubc(sender_endpoint, socket, io_service);
+    boost::system::error_code ec;
+    ubc.receive(boost::asio::buffer(&packet_received, sizeof packet_received), boost::posix_time::seconds(static_cast<long>(timeout_sec)), ec);
+    if(ec) {
+      LOG_PRINT_L3("NTP: get_ntp_time(" << host_name << "): boost error: " << ec.message());
       return 0;
     }
-    catch (...)
-    {
-      LOG_PRINT_L2("NTP: get_ntp_time(" << host_name << "): unknown exception");
+
+    auto packet_received_time = std::chrono::high_resolution_clock::now();
+    int64_t roundtrip_mcs     = std::chrono::duration_cast<std::chrono::microseconds>(packet_received_time - packet_sent_time).count();
+    uint64_t roundtrip_s      = roundtrip_mcs > 2000000 ? roundtrip_mcs / 2000000 : 0;
+
+    time_t ntp_time = ntohl(packet_received.txTm_s);
+    if(ntp_time <= 2208988800U) {
+      LOG_PRINT_L3("NTP: get_ntp_time(" << host_name << "): wrong txTm_s: " << packet_received.txTm_s);
       return 0;
+    }
+    // LOG_PRINT_L2("NTP: get_ntp_time(" << host_name << "): RAW time received: " << ntp_time << ", refTm_s: " << ntohl(packet_received.refTm_s) << ", stratum: " << packet_received.stratum << ", round: " << roundtrip_mcs);
+    ntp_time -= 2208988800U;  // Unix time starts from 01/01/1970 == 2208988800U
+    ntp_time += roundtrip_s;
+    return ntp_time;
+  }
+  catch(const std::exception& e) {
+    LOG_PRINT_L2("NTP: get_ntp_time(" << host_name << "): exception: " << e.what());
+    return 0;
+  }
+  catch(...) {
+    LOG_PRINT_L2("NTP: get_ntp_time(" << host_name << "): unknown exception");
+    return 0;
+  }
+}
+
+#define TIME_SYNC_NTP_SERVERS "time1.google.com", "time2.google.com", "time3.google.com", "time4.google.com" /* , "pool.ntp.org" -- we need to request a vender zone before using this pool */
+#define TIME_SYNC_NTP_TIMEOUT_SEC 5
+#define TIME_SYNC_NTP_ATTEMPTS_COUNT 3  // max number of attempts when getting time from NTP server
+
+int64_t get_ntp_time()
+{
+  static const std::vector<std::string> ntp_servers { TIME_SYNC_NTP_SERVERS };
+
+  for(size_t att = 0; att < TIME_SYNC_NTP_ATTEMPTS_COUNT; ++att) {
+    const std::string& ntp_server = ntp_servers[att % ntp_servers.size()];
+    LOG_PRINT_L3("NTP: trying to get time from " << ntp_server);
+    int64_t time = get_ntp_time(ntp_server, TIME_SYNC_NTP_TIMEOUT_SEC);
+    if(time > 0) {
+      LOG_PRINT_L3("NTP: " << ntp_server << " responded with " << time << " (" << epee::misc_utils::get_time_str_v2(time) << ")");
+      return time;
     }
   }
 
+  LOG_PRINT_RED("NTP: unable to get time from NTP with " << TIME_SYNC_NTP_ATTEMPTS_COUNT << " trials", LOG_LEVEL_2);
+  return 0;  // smth went wrong
+}
 
-  #define TIME_SYNC_NTP_SERVERS            "time1.google.com", "time2.google.com", "time3.google.com", "time4.google.com" /* , "pool.ntp.org" -- we need to request a vender zone before using this pool */
-  #define TIME_SYNC_NTP_TIMEOUT_SEC        5
-  #define TIME_SYNC_NTP_ATTEMPTS_COUNT     3  // max number of attempts when getting time from NTP server
-
-  int64_t get_ntp_time()
-  {
-    static const std::vector<std::string> ntp_servers { TIME_SYNC_NTP_SERVERS };
-
-    for (size_t att = 0; att < TIME_SYNC_NTP_ATTEMPTS_COUNT; ++att)
-    {
-      const std::string& ntp_server = ntp_servers[att % ntp_servers.size()];
-      LOG_PRINT_L3("NTP: trying to get time from " << ntp_server);
-      int64_t time = get_ntp_time(ntp_server, TIME_SYNC_NTP_TIMEOUT_SEC);
-      if (time > 0)
-      {
-        LOG_PRINT_L3("NTP: " << ntp_server << " responded with " << time << " (" << epee::misc_utils::get_time_str_v2(time) << ")");
-        return time;
-      }
-    }
-
-    LOG_PRINT_RED("NTP: unable to get time from NTP with " << TIME_SYNC_NTP_ATTEMPTS_COUNT << " trials", LOG_LEVEL_2);
-    return 0; // smth went wrong
-  }
-
-
-
-} // namespace tools
+}  // namespace tools


### PR DESCRIPTION
Make needed changes to compile project with boost 1.75.
There are still a lot of annoying warnings, but those are left for future commits.
The files have been formatted with the project's .clang-format style.