### PR TITLE
added zano url-scheme handler MacOS, Windows, Linux setups

### DIFF
--- a/src/gui/qt-daemon/Info.plist.in
+++ b/src/gui/qt-daemon/Info.plist.in
@@ -45,10 +45,19 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
-
-        <key>NSHighResolutionCapable</key>
-        <string>True</string>
-
+	<key>NSHighResolutionCapable</key>
+    <string>True</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ZanoApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>zano</string>
+			</array>
+		</dict>
+	</array>
 
 </dict>
 </plist>

--- a/utils/Zano.sh
+++ b/utils/Zano.sh
@@ -33,9 +33,12 @@ create_desktop_icon()
     echo Terminal=true | tee -a $target_file_name  > /dev/null
     echo Type=Application | tee -a $target_file_name  > /dev/null
     echo "Categories=Qt;Utility;" | tee -a $target_file_name  > /dev/null
+    echo "MimeType=x-scheme-handler/zano;" | tee -a $target_file_name  > /dev/null
 }
 
 
 create_desktop_icon $out_file_name
+
+xdg-mime default Zano.desktop x-scheme-handler/zano
 
 call_app

--- a/utils/setup_32.iss
+++ b/utils/setup_32.iss
@@ -51,6 +51,8 @@ Root: HKCR; Subkey: "ZanoWalletDataKyesFile"; ValueType: string; ValueName: ""; 
 Root: HKCR; Subkey: "ZanoWalletDataFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\zano.exe,0"
 Root: HKCR; Subkey: "ZanoWalletDataKyesFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\zano.exe,0"
 
+Root: HKCR; Subkey: "Zano"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCR; Subkey: "Zano\shell\open\command"; ValueType: string; ValueName: ""; ValueData: "{app}\zano.exe %1"
 
 [Files]
 

--- a/utils/setup_64.iss
+++ b/utils/setup_64.iss
@@ -52,6 +52,9 @@ Root: HKCR; Subkey: "ZanoWalletDataKyesFile"; ValueType: string; ValueName: ""; 
 Root: HKCR; Subkey: "ZanoWalletDataFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\Zano.exe,0"
 Root: HKCR; Subkey: "ZanoWalletDataKyesFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\Zano.exe,0"
 
+Root: HKCR; Subkey: "Zano"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCR; Subkey: "Zano\shell\open\command"; ValueType: string; ValueName: ""; ValueData: "{app}\Zano.exe %1"
+
 
 [Files]
 


### PR DESCRIPTION
Zano GUI application launches when user clicks a specialized url (zano:xxxx) in a web site and web browsers (Safari, Chrome, Edge, Firefox, Internet Explorer).