### PR TITLE
Fixes CMAKE_OSX_DEPLOYMENT_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ enable_testing()
 
 
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10.5)          
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10.5 CACHE STRING "Minimum OS X deployment version")          
 endif()
 
 set(USE_PCH FALSE CACHE BOOL "Use shared precompiled headers")


### PR DESCRIPTION
Hiya,

When compiling on macOS, i get "ld: warning: dylib (/opt/homebrew/lib/libboost_filesystem-mt.dylib) was built for newer macOS version (13.0) than being linked (11.0)"

<img width="979" alt="image" src="https://user-images.githubusercontent.com/631881/210154716-7090c36b-ccb0-4f34-a5fe-278d5ae80da2.png">

This is fixed by adding "CACHE STRING" to CMAKE_OSX_DEPLOYMENT_TARGET

<img width="775" alt="image" src="https://user-images.githubusercontent.com/631881/210154776-95c3f89a-84d9-44b6-8eab-aa7967b9a851.png">

