### PR TITLE
tweaks for ubuntu 22.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Thumbs.db
 ._*
 .idea
 .vs/*
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ Recommended OS versions: Ubuntu 20.04, 22.04 LTS.
 6. [*OPTIONAL*] Set global environment variables for convenient use\
 For instance, by adding the following lines to `~/.bashrc`
 
+    ### Ubuntu 22.04
+
+    [*server version*]
+
+       export Boost_INCLUDE_DIRS=/usr/include/boost
+       export ZANO_USE_SYSTEM_BOOST
+
+
+    [*GUI version*]
+
+       export Boost_INCLUDE_DIRS=/usr/include/boost
+       export ZANO_USE_SYSTEM_BOOST 
+       export QT_PREFIX_PATH=/home/user/Qt5.11.2/5.11.2/gcc_64
+
+      **NOTICE: Please edit the lines above according to your actual paths.**
+   
+      **NOTICE 2:** Make sure you've restarted your terminal session (by reopening the terminal window or reconnecting the server) to apply these changes.
+
+    ### Ubuntu 18.04 & 20.04
+
     [*server version*]
 
        export BOOST_ROOT=/home/user/boost_1_70_0  

--- a/src/currency_core/bc_offers_service.h
+++ b/src/currency_core/bc_offers_service.h
@@ -5,6 +5,9 @@
 
 #pragma once
 #include <boost/serialization/serialization.hpp>
+#if BOOST_VERSION >= 107400
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/version.hpp>
 #include <boost/serialization/list.hpp>
 

--- a/src/wallet/decoy_selection.h
+++ b/src/wallet/decoy_selection.h
@@ -4,6 +4,10 @@
 
 #pragma once
 #include <memory>
+#include <boost/serialization/serialization.hpp>
+#if BOOST_VERSION >= 107400
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/deque.hpp>

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -6,6 +6,10 @@
 
 #pragma once
 #include <memory>
+#include <boost/serialization/serialization.hpp>
+#if BOOST_VERSION >= 107400
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/deque.hpp>

--- a/src/wallet/wallet_chain_shortener.h
+++ b/src/wallet/wallet_chain_shortener.h
@@ -5,6 +5,10 @@
 #pragma once
 #pragma once
 #include <memory>
+#include <boost/serialization/serialization.hpp>
+#if BOOST_VERSION >= 107400
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/deque.hpp>


### PR DESCRIPTION
fixes the following issue compiling on ubuntu 22.04

` error: ‘library_version_type’ in namespace ‘boost::serialization’ does not name a type; did you mean ‘item_version_type’?`

I'm no c++ expert so there could be a better way to do this!