### PR TITLE
Unit tests: repair compilation on the g++ 12 compiler

### DIFF
--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -26,10 +26,12 @@ struct Struct
   char blob[8];
 };
 
-
-std::ostream& operator <<(std::ostream& o, const currency::signature_v& v)
+namespace currency
 {
-  return o;
+  ostream& operator<<(ostream& stream, [[maybe_unused]] const currency::signature_v& signature)
+  {
+    return stream;
+  }
 }
 
 template <class Archive>


### PR DESCRIPTION
In the G++ 12 two-stage name lookup for dependent operator expressions has been corrected. This correction broke successful compilation of the test "Serialization.serializes_transacion_signatures_correctly" source code. A solution is put a definition of the "operator<<" of the type "std::ostream&(std::ostream&, currency::signature_v&)" to the namespace "currency".

I came up with 2 source texts where you can feel the G++ 12 change. A source code below will be compiled on the G++ 11, but won't be compiled on the G++ 12.
```cpp
#include <iostream>

namespace ns_a
{
  class c_a
  {
  };
}

template<class T_0, class T_1>
void f(T_0& stream, T_1& o)
{
  stream << o;
}

std::ostream& operator<<(std::ostream& stream, ns_a::c_a&)
{
  return stream;
}

int main()
{
  ns_a::c_a o{};

  f(std::cout, o);
}
```

A source code below will be compiled on the G++ 11, on the G++ 12.
```cpp
#include <iostream>

namespace ns_a
{
  class c_a
  {
  };
}

template<class T_0, class T_1>
void f(T_0& stream, T_1& o)
{
  stream << o;
}

namespace ns_a
{
  std::ostream& operator<<(std::ostream& stream, ns_a::c_a&)
  {
    return stream;
  }
}

int main()
{
  ns_a::c_a o{};

  f(std::cout, o);
}
```

[Bug 51577](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51577) - dependent name lookup finds operator in global namespace