### PR TITLE
docs: change boost upstream source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Recommended OS versions: Ubuntu 20.04, 22.04 LTS.
 3. Download and build Boost\
     (Assuming you have cloned Zano into the 'zano' folder. If you used a different location for Zano, **edit line 4** accordingly.)
 
-       curl -OL https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2
+       curl -OL https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
        echo "cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454  boost_1_84_0.tar.bz2" | shasum -c && tar -xjf boost_1_84_0.tar.bz2
        rm boost_1_84_0.tar.bz2 && cd boost_1_84_0
        ./bootstrap.sh --with-libraries=system,filesystem,thread,date_time,chrono,regex,serialization,atomic,program_options,locale,timer,log


### PR DESCRIPTION
The Artifactory mirror has been offline since sometime on December 31st, 2024.

Same hash, different source URL.

The one in the current docs, https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2 just takes me to Artifactory's landing page.

![image](https://github.com/user-attachments/assets/c675daf6-3620-4542-a307-660a08ab1392)
