### PR TITLE
add keys to open_wallet_response

### DIFF
--- a/src/wallet/view_iface.h
+++ b/src/wallet/view_iface.h
@@ -452,6 +452,10 @@ public:
     transfers_array recent_history;
     wallet_info wi;
     std::string seed;
+    std::string private_spend_key;
+    std::string private_view_key;
+    std::string public_spend_key;
+    std::string public_view_key;
     bool recovered;
     uint64_t wallet_local_bc_size;
     uint64_t wallet_file_size;
@@ -463,6 +467,10 @@ public:
       KV_SERIALIZE(recent_history)
       KV_SERIALIZE(wi)
       KV_SERIALIZE(seed)
+      KV_SERIALIZE(private_spend_key)
+      KV_SERIALIZE(private_view_key)
+      KV_SERIALIZE(public_spend_key)
+      KV_SERIALIZE(public_view_key)
       KV_SERIALIZE(recovered)
       KV_SERIALIZE(wallet_local_bc_size)
       KV_SERIALIZE(wallet_file_size)

--- a/src/wallet/wallets_manager.cpp
+++ b/src/wallet/wallets_manager.cpp
@@ -1086,6 +1086,13 @@ std::string wallets_manager::open_wallet(const std::wstring& path, const std::st
 
       //workaround for missed fee
       owr.seed = w->get_account().get_seed_phrase("");
+      auto& keys = w->get_account().get_keys();
+
+      owr.private_view_key = epee::string_tools::pod_to_hex(keys.view_secret_key);
+      owr.public_view_key  = epee::string_tools::pod_to_hex(keys.account_address.view_public_key);
+      owr.private_spend_key = epee::string_tools::pod_to_hex(keys.spend_secret_key);
+      owr.public_spend_key = epee::string_tools::pod_to_hex(keys.account_address.spend_public_key);
+      // open_wallet_response
       break;
     }
     catch (const tools::error::file_not_found& /**/)
@@ -1197,6 +1204,12 @@ std::string wallets_manager::generate_wallet(const std::wstring& path, const std
     w->generate(path, password, false);
     w->set_minimum_height(m_last_daemon_height-1);
     owr.seed = w->get_account().get_seed_phrase("");
+    auto& keys = w->get_account().get_keys();
+
+    owr.private_view_key = epee::string_tools::pod_to_hex(keys.view_secret_key);
+    owr.public_view_key  = epee::string_tools::pod_to_hex(keys.account_address.view_public_key);
+    owr.private_spend_key = epee::string_tools::pod_to_hex(keys.spend_secret_key);
+    owr.public_spend_key = epee::string_tools::pod_to_hex(keys.account_address.spend_public_key);
   }
   catch (const tools::error::file_exists&)
   {
@@ -1306,6 +1319,12 @@ std::string wallets_manager::restore_wallet(const std::wstring& path, const std:
     bool is_tracking = currency::account_base::is_seed_tracking(seed_phrase);
     w->restore(path, password, seed_phrase, is_tracking, seed_password);
     owr.seed = w->get_account().get_seed_phrase("");
+    auto& keys = w->get_account().get_keys();
+
+    owr.private_view_key = epee::string_tools::pod_to_hex(keys.view_secret_key);
+    owr.public_view_key  = epee::string_tools::pod_to_hex(keys.account_address.view_public_key);
+    owr.private_spend_key = epee::string_tools::pod_to_hex(keys.spend_secret_key);
+    owr.public_spend_key = epee::string_tools::pod_to_hex(keys.account_address.spend_public_key);
   }
   catch (const tools::error::file_exists&)
   {


### PR DESCRIPTION
This allows Cake Wallet to show keys before the wallet is fully synchronized by simply parsing open_wallet_response.