### PR TITLE
relax mutex in invoke call

### DIFF
--- a/src/common/error_codes.h
+++ b/src/common/error_codes.h
@@ -45,3 +45,4 @@
 #define API_RETURN_CODE_HTLC_ORIGIN_HASH_MISSMATCHED            "HTLC_ORIGIN_HASH_MISSMATCHED"
 #define API_RETURN_CODE_WRAP                                    "WRAP"
 #define API_RETURN_CODE_MISSING_ZC_INPUTS                       "MISSING_ZC_INPUTS"
+#define API_RETURN_CODE_BAD_JSON                                "BAD_JSON"


### PR DESCRIPTION
This fixes large lag when waiting on mutex, when
user requested data/action that doesn't change but another action that requires mutex is pending.
This fixes access delay when switching wallets in
Cake Wallet.

We were making multiple invoke() calls to obtain
wallet name, decrypt a string to get passphrase
and finally get the encrypted seed, now we do
exactly the same but we don't have to wait for
other calls to finish.

https://github.com/MrCyjaneK/zano/blob/b23663b861a0a780bbe530b550c0d9a510705aec/src/wallet/wallets_manager.cpp#L1715-L1724

```cpp
  if (req.method != "assets_whitelist_get" &&
      req.method != "decrypt_data" &&
      req.method != "encrypt_data" &&
      req.method != "get_restore_info" &&
      req.method != "get_seed_phrase_info" &&
      req.method != "get_wallet_info" &&
      req.method != "getaddress" &&
      req.method != "getbalance" &&
      req.method != "sign_message") {
```

This if statement was created by just looking over the docs and making a "guess" on the function behavior, these above should not cause any troubles if executed alongside others (at least it is working fine in cake wallet - confirmed by me, it is not yet released or tested by others)

[included patch](https://github.com/MrCyjaneK/monero_c/pull/120)