### PR TITLE
fix: input password bug

### DIFF
--- a/src/simplewallet/password_container.cpp
+++ b/src/simplewallet/password_container.cpp
@@ -232,7 +232,10 @@ namespace tools
       else
       {
         m_password.push_back(ch);
-        std::cout << (char_to_replace_user_input != '\0' ? char_to_replace_user_input : ch);
+        std::cout.put((
+          char_to_replace_user_input != '\0' ? 
+          char_to_replace_user_input : static_cast<char>(ch))
+        ).flush();
       }
     }
 


### PR DESCRIPTION
bug - https://github.com/hyle-team/zano/issues/525

Ternary expression mixing char and int

```
std::cout << (char_to_replace_user_input != '\0'
                 ? char_to_replace_user_input
                 : ch);
```

Here, char_to_replace_user_input is a char (e.g. '*' whose ASCII code is 42) and ch is an int. C++ promotes the char operand to int, so the entire expression is of type int. When streaming an int, operator<< prints its decimal value (“42”) rather than the single character

Before:
![image](https://github.com/user-attachments/assets/08642fa4-3096-41f9-a430-1158fa579e82)


After:
![image](https://github.com/user-attachments/assets/a456ecd1-fc20-4e39-858d-6515a5809a64)
