### PR TITLE
changed -flto to -flto=auto to enable gcc parallel link-time optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ else()
   set(RELEASE_FLAGS "-Ofast -DNDEBUG -Wno-unused-variable")
 
   if(NOT APPLE AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Android"))
-    set(RELEASE_FLAGS "${RELEASE_FLAGS} -flto -g3")
+    set(RELEASE_FLAGS "${RELEASE_FLAGS} -flto=auto -g3")
   endif()
   #if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT MINGW)
   #  set(RELEASE_FLAGS "${RELEASE_FLAGS} -fno-fat-lto-objects")


### PR DESCRIPTION


Enable parallel LTO for faster release builds

Changed `-flto` to `-flto=auto` to enable parallel link-time optimization

**Before**

LTO jobs were executed serially (128 jobs one by one), causing long build times
warnings:
```bash
lto-wrapper: warning: using serial compilation of 128 LTRANS jobs
lto-wrapper: note: see the ‘-flto’ option documentation for more information
```
**After**

LTO jobs run in parallel across all available CPU cores


```
Before -flto
real    10m14.127s
user    85m32.779s
sys    4m31.868s

After -flto=auto
real    6m3.446s
user    81m35.895s
sys    4m35.589s
```