### PR TITLE
p2p: do not send last_seen timestamp to peers

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -193,12 +193,12 @@ namespace nodetool
     bool parse_peerlist(const std::vector<std::string>& perrs_str, std::list<nodetool::net_address>& peers);
     bool handle_command_line(const boost::program_options::variables_map& vm);
     bool idle_worker();
-    bool handle_remote_peerlist(const std::list<peerlist_entry>& peerlist, time_t local_time, const net_utils::connection_context_base& context);
+    bool handle_remote_peerlist(const std::vector<peerlist_entry>& peerlist, time_t local_time, const net_utils::connection_context_base& context);
     bool get_local_node_data(basic_node_data& node_data);
     //bool get_local_handshake_data(handshake_data& hshd);
 
-    bool merge_peerlist_with_local(const std::list<peerlist_entry>& bs);
-    bool fix_time_delta(std::list<peerlist_entry>& local_peerlist, time_t local_time, int64_t& delta);
+    bool merge_peerlist_with_local(const std::vector<peerlist_entry>& bs);
+    bool fix_time_delta(std::vector<peerlist_entry>& local_peerlist, time_t local_time, int64_t& delta);
 
     bool connections_maker();
     bool peer_sync_idle_maker();
@@ -285,7 +285,7 @@ namespace nodetool
     std::list<net_address>   m_priority_peers;
     bool m_use_only_priority_peers;
     std::vector<net_address> m_seed_nodes;
-    std::list<nodetool::peerlist_entry> m_command_line_peers;
+    std::vector<nodetool::peerlist_entry> m_command_line_peers;
     int64_t m_peer_livetime;
     //keep connections to initiate some interactions
     net_server m_net_server;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1198,7 +1198,7 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::fix_time_delta(std::list<peerlist_entry>& local_peerlist, time_t local_time, int64_t& delta)
+  bool node_server<t_payload_net_handler>::fix_time_delta(std::vector<peerlist_entry>& local_peerlist, time_t local_time, int64_t& delta)
   {
     //fix time delta
     time_t now = 0;
@@ -1218,10 +1218,10 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::handle_remote_peerlist(const std::list<peerlist_entry>& peerlist, time_t local_time, const net_utils::connection_context_base& context)
+  bool node_server<t_payload_net_handler>::handle_remote_peerlist(const std::vector<peerlist_entry>& peerlist, time_t local_time, const net_utils::connection_context_base& context)
   {
     int64_t delta = 0;
-    std::list<peerlist_entry> peerlist_ = peerlist;
+    std::vector<peerlist_entry> peerlist_ = peerlist;
     if(!fix_time_delta(peerlist_, local_time, delta))
       return false;
     LOG_PRINT_L2("REMOTE PEERLIST: TIME_DELTA: " << delta << ", remote peerlist size=" << peerlist_.size());
@@ -1495,7 +1495,7 @@ namespace nodetool
 
     //fill response
     rsp.local_time = time(NULL);
-    m_peerlist.get_peerlist_head(rsp.local_peerlist);
+    m_peerlist.get_peerlist_head(rsp.local_peerlist, true);
     m_payload_handler.get_payload_sync_data(rsp.payload_data);
     fill_maintainers_entry(rsp.maintrs_entry);
     LOG_PRINT_L3("COMMAND_TIMED_SYNC");
@@ -1579,7 +1579,7 @@ namespace nodetool
     }
 
     //fill response
-    m_peerlist.get_peerlist_head(rsp.local_peerlist);
+    m_peerlist.get_peerlist_head(rsp.local_peerlist, true);
     get_local_node_data(rsp.node_data);
     m_payload_handler.get_payload_sync_data(rsp.payload_data);
     fill_maintainers_entry(rsp.maintrs_entry);
@@ -1599,8 +1599,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::log_peerlist()
   {
-    std::list<peerlist_entry> pl_wite;
-    std::list<peerlist_entry> pl_gray;
+    std::vector<peerlist_entry> pl_wite;
+    std::vector<peerlist_entry> pl_gray;
     m_peerlist.get_peerlist_full(pl_gray, pl_wite);
     LOG_PRINT_L0(ENDL << "Peerlist white:" << ENDL << print_peerlist_to_string(pl_wite) << ENDL << "Peerlist gray:" << ENDL << print_peerlist_to_string(pl_gray) );
     return true;

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -44,9 +44,9 @@ namespace nodetool
     bool deinit();
     size_t get_white_peers_count(){CRITICAL_REGION_LOCAL(m_peerlist_lock); return m_peers_white.size();}
     size_t get_gray_peers_count(){CRITICAL_REGION_LOCAL(m_peerlist_lock); return m_peers_gray.size();}
-    bool merge_peerlist(const std::list<peerlist_entry>& outer_bs);
-    bool get_peerlist_head(std::list<peerlist_entry>& bs_head, uint32_t depth = P2P_DEFAULT_PEERS_IN_HANDSHAKE);
-    bool get_peerlist_full(std::list<peerlist_entry>& pl_gray, std::list<peerlist_entry>& pl_white);
+    bool merge_peerlist(const std::vector<peerlist_entry>& outer_bs);
+    bool get_peerlist_head(std::vector<peerlist_entry>& bs_head, bool anonymize, uint32_t depth = P2P_DEFAULT_PEERS_IN_HANDSHAKE);
+    bool get_peerlist_full(std::vector<peerlist_entry>& pl_gray, std::vector<peerlist_entry>& pl_white);
     bool get_white_peer_by_index(peerlist_entry& p, size_t i);
     bool get_gray_peer_by_index(peerlist_entry& p, size_t i);
     bool append_with_peer_white(const peerlist_entry& pr);
@@ -194,7 +194,7 @@ namespace nodetool
   }
   //--------------------------------------------------------------------------------------------------
   inline 
-  bool peerlist_manager::merge_peerlist(const std::list<peerlist_entry>& outer_bs)
+  bool peerlist_manager::merge_peerlist(const std::vector<peerlist_entry>& outer_bs)
   {
     CRITICAL_REGION_LOCAL(m_peerlist_lock);
     BOOST_FOREACH(const peerlist_entry& be,  outer_bs)
@@ -244,25 +244,43 @@ namespace nodetool
   }
   //--------------------------------------------------------------------------------------------------
   inline 
-  bool peerlist_manager::get_peerlist_head(std::list<peerlist_entry>& bs_head, uint32_t depth)
+  bool peerlist_manager::get_peerlist_head(std::vector<peerlist_entry>& bs_head, bool anonymize, uint32_t depth)
   {
     
     CRITICAL_REGION_LOCAL(m_peerlist_lock);
     peers_indexed::index<by_time>::type& by_time_index=m_peers_white.get<by_time>();
     uint32_t cnt = 0;
+
+    // The fix was made using Monero -> 28a7d31
+    // picks a random set of peers within the first 120%, rather than a set of the first 100%.
+    // The intent is that if someone asks twice, they can't easily tell:
+    // - this address was not in the first list, but is in the second, so the only way this can be
+    // is if its last_seen was recently reset, so this means the target node recently had a new
+    // connection to that address
+    // - this address was in the first list, and not in the second, which means either the address
+    // was moved to the gray list (if it's not accessibe, which the attacker can check if
+    // the address accepts incoming connections) or it was the oldest to still fit in the 250 items,
+    // so its last_seen is old.
+    const uint32_t pick_depth = anonymize ? depth + depth / 5 : depth;
     BOOST_REVERSE_FOREACH(const peers_indexed::value_type& vl, by_time_index)
     {
-      if(!vl.last_seen)
-        continue;
-      bs_head.push_back(vl);      
-      if(cnt++ > depth)
+      if(cnt++ >= pick_depth)
         break;
+      bs_head.push_back(vl);
+    }
+    if (anonymize)
+    {
+      std::shuffle(bs_head.begin(), bs_head.end(), crypto::uniform_random_bit_generator());
+      if (bs_head.size() > depth)
+        bs_head.resize(depth);
+      for (auto &e: bs_head)
+        e.last_seen = 0;
     }
     return true;
   }
   //--------------------------------------------------------------------------------------------------
   inline
-  bool peerlist_manager::get_peerlist_full(std::list<peerlist_entry>& pl_gray, std::list<peerlist_entry>& pl_white)
+  bool peerlist_manager::get_peerlist_full(std::vector<peerlist_entry>& pl_gray, std::vector<peerlist_entry>& pl_white)
   {    
     CRITICAL_REGION_LOCAL(m_peerlist_lock);
     peers_indexed::index<by_time>::type& by_time_index_gr=m_peers_gray.get<by_time>();

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -60,7 +60,7 @@ namespace nodetool
     return  memcmp(&a, &b, sizeof(a)) == 0;
   }
   inline 
-  std::string print_peerlist_to_string(const std::list<peerlist_entry>& pl)
+  std::string print_peerlist_to_string(const std::vector<peerlist_entry>& pl)
   {
     time_t now_time = 0;
     time(&now_time);
@@ -68,7 +68,7 @@ namespace nodetool
     ss << std::setfill ('0') << std::setw (8) << std::hex << std::noshowbase;
     BOOST_FOREACH(const peerlist_entry& pe, pl)
     {
-      ss << pe.id << "\t" << epee::string_tools::get_ip_string_from_int32(pe.adr.ip) << ":" << boost::lexical_cast<std::string>(pe.adr.port) << " \tlast_seen: " << epee::misc_utils::get_time_interval_string(now_time - pe.last_seen) << std::endl;
+      ss << pe.id << "\t" << epee::string_tools::get_ip_string_from_int32(pe.adr.ip) << ":" << boost::lexical_cast<std::string>(pe.adr.port) << " \tlast_seen: " << (pe.last_seen == 0 ? std::string("never") :  epee::misc_utils::get_time_interval_string(now_time - pe.last_seen)) << std::endl;
     }
     return ss.str();
   }
@@ -207,7 +207,7 @@ namespace nodetool
     {
       basic_node_data node_data;
       t_playload_type payload_data;
-      std::list<peerlist_entry> local_peerlist;
+      std::vector<peerlist_entry> local_peerlist;
       maintainers_entry maintrs_entry;
 
       BEGIN_KV_SERIALIZE_MAP()
@@ -243,7 +243,7 @@ namespace nodetool
     {
       int64_t local_time;
       t_playload_type payload_data;
-      std::list<peerlist_entry> local_peerlist; 
+      std::vector<peerlist_entry> local_peerlist; 
       maintainers_entry maintrs_entry;
 
       BEGIN_KV_SERIALIZE_MAP()
@@ -383,8 +383,8 @@ namespace nodetool
 
     struct response
     {
-      std::list<peerlist_entry> local_peerlist_white; 
-      std::list<peerlist_entry> local_peerlist_gray; 
+      std::vector<peerlist_entry> local_peerlist_white; 
+      std::vector<peerlist_entry> local_peerlist_gray; 
       std::list<connection_entry> connections_list; 
       peerid_type my_id;
       uint64_t    local_time;

--- a/tests/unit_tests/test_peerlist.cpp
+++ b/tests/unit_tests/test_peerlist.cpp
@@ -31,8 +31,8 @@ TEST(peer_list, peer_list_general)
   size_t gray_list_size = plm.get_gray_peers_count();
   ASSERT_EQ(gray_list_size, 1);
 
-  std::list<nodetool::peerlist_entry> bs_head;
-  bool r = plm.get_peerlist_head(bs_head, 100);
+  std::vector<nodetool::peerlist_entry> bs_head;
+  bool r = plm.get_peerlist_head(bs_head, false, 100);
   std::cout << bs_head.size() << std::endl;
   ASSERT_TRUE(r);
 


### PR DESCRIPTION
Fix made with help Monero `28a7d31`

This can be used for fingerprinting and working out the
network topology.

Instead of sending the first N (which are sorted by last
seen time), we sent a random subset of the first N+N/5,
which ensures reasonably recent peers are used, while
preventing repeated calls from deducing new entries are
peers the target node just connected to.

The list is also randomly shuffled so the original set of
timestamps cannot be approximated.