### PR TITLE
coretests: add optional --report-block-stats per test end-of-test blockchain snapshot summary

### DIFF
--- a/tests/core_tests/chaingen_args.cpp
+++ b/tests/core_tests/chaingen_args.cpp
@@ -14,6 +14,7 @@ namespace chaingen_args
   command_line::arg_descriptor<std::string> arg_run_multiple_tests           ("run-multiple-tests", "comma-separated list of tests to run, OR text file <@filename> containing list of tests");
   command_line::arg_descriptor<bool>        arg_enable_debug_asserts         ("enable-debug-asserts", "" );
   command_line::arg_descriptor<bool>        arg_stop_on_fail                 ("stop-on-fail", "");
+  command_line::arg_descriptor<bool>        arg_report_block_stats           ("report-block-stats", "Capture an end-of-test blockchain snapshot (chain size, top height, alt blocks, pool tx count) for every coretest and print a summary table at the end. Propagates to workers in --multiprocess-run mode.");
   command_line::arg_descriptor<uint32_t>    arg_processes                    ("multiprocess-run", "Run tests in parallel using the specified number of worker processes", 1);
   command_line::arg_descriptor<int32_t>     arg_worker_id                    ("multiprocess-worker-id", "Internal: index of the worker process (assigned automatically by parent)", -1);
   command_line::arg_descriptor<std::string> arg_run_root                     ("multiprocess-run-root", "Internal: directory used by parent and workers to store run artifacts and reports", "");

--- a/tests/core_tests/chaingen_args.h
+++ b/tests/core_tests/chaingen_args.h
@@ -16,6 +16,7 @@ namespace chaingen_args
   extern command_line::arg_descriptor<std::string> arg_run_multiple_tests;
   extern command_line::arg_descriptor<bool>        arg_enable_debug_asserts;
   extern command_line::arg_descriptor<bool>        arg_stop_on_fail;
+  extern command_line::arg_descriptor<bool>        arg_report_block_stats;
   extern command_line::arg_descriptor<uint32_t>    arg_processes;
   extern command_line::arg_descriptor<int32_t>     arg_worker_id;
   extern command_line::arg_descriptor<std::string> arg_run_root;

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -19,6 +19,7 @@
 #include "common/callstack_helper.h"
 
 #define TX_BLOBSIZE_CHECKER_LOG_FILENAME "get_object_blobsize(tx).log"
+#define BLOCK_STATS_LOG_FILENAME         "coretests_block_stats.log"
 
 using namespace chaingen_args;
 
@@ -33,6 +34,9 @@ namespace
   coretests_shm::shared_state* g_shm_state = nullptr;
   std::unique_ptr<boost::interprocess::mapped_region> g_shm_region;
   thread_local int32_t g_current_job_idx = -1;
+  bool g_report_block_stats = false;
+  std::vector<std::pair<std::string, test_block_stats>> g_test_block_stats;
+  thread_local std::string g_current_test_name;
 }
 
 #define GENERATE(filename, genclass) \
@@ -243,8 +247,12 @@ bool generate_and_play(const char* const genclass_name, size_t hardfork_id = SIZ
       LOG_PRINT_MAGENTA(std::string(100, '=') << std::endl <<
         "#TEST# >>>> " << genclass_name << " <<<< start replaying events" << std::endl <<
         std::string(100, '=') << std::endl, LOG_LEVEL_0);
-      
+
+      if (g_report_block_stats)
+        g_current_test_name = genclass_name;
       result = do_replay_events(events, g);
+      if (g_report_block_stats)
+        g_current_test_name.clear();
     }
   }
   catch (const std::exception& ex)
@@ -329,7 +337,11 @@ bool gen_and_play_intermitted_by_blockchain_saveload(const char* const genclass_
   uint64_t core_time = test_core_time::get_time();
   {
     random_state_test_restorer random_restorer; // use it to achive equal random generator's state before Stage 1 and before Stage 2
+    if (g_report_block_stats)
+      g_current_test_name = genclass_name;
     r = do_replay_events(events, g, 0, SIZE_MAX, false, [](currency::core&) {}, [&core_state_before](currency::core& c) { core_state_before.fill(c); });
+    if (g_report_block_stats)
+      g_current_test_name.clear();
     if (!r)
       return false;
     std::cout << concolor::green << "#TEST# " << genclass_name << ": STAGE 1: Succeeded (all events were played back normally)" << concolor::normal << std::endl;
@@ -792,6 +804,39 @@ inline bool do_replay_events(const std::vector<test_event_entry>& events, t_test
   }
 
   before_deinit_cb(c);
+
+  // сapture end-of-test block stats when the feature is enabled --report-block-stats
+  if (g_report_block_stats && !g_current_test_name.empty())
+  {
+    test_block_stats stats;
+    stats.blockchain_size  = c.get_blockchain_storage().get_current_blockchain_size();
+    stats.top_block_height = c.get_blockchain_storage().get_top_block_height();
+    stats.alt_blocks_count = c.get_blockchain_storage().get_alternative_blocks_count();
+    stats.pool_tx_count    = c.get_pool_transactions_count();
+
+    bool replaced = false;
+    for (auto& p : g_test_block_stats)
+    {
+      if (p.first == g_current_test_name)
+      {
+        p.second = stats;
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced)
+      g_test_block_stats.emplace_back(g_current_test_name, stats);
+
+    const int32_t wid = command_line::get_arg(g_vm, chaingen_args::arg_worker_id);
+    LOG_PRINT2(BLOCK_STATS_LOG_FILENAME,
+      "#TEST# " << g_current_test_name
+      << (wid >= 0 ? " [w" + std::to_string(wid) + "]" : std::string())
+      << "  chain_size=" << stats.blockchain_size
+      << "  top_height=" << stats.top_block_height
+      << "  alt_blocks=" << stats.alt_blocks_count
+      << "  pool_txs="   << stats.pool_tx_count,
+      LOG_LEVEL_0);
+  }
 
   c.deinit(); // always deinitialize the core
   protocol_handler.deinit();
@@ -1455,6 +1500,7 @@ int main(int argc, char* argv[])
   command_line::add_arg(desc_options, arg_run_multiple_tests);
   command_line::add_arg(desc_options, arg_enable_debug_asserts);
   command_line::add_arg(desc_options, arg_stop_on_fail);
+  command_line::add_arg(desc_options, arg_report_block_stats);
   command_line::add_arg(desc_options, command_line::arg_data_dir, std::string("."));
   command_line::add_arg(desc_options, command_line::arg_stop_after_height);
   command_line::add_arg(desc_options, command_line::arg_disable_ntp);
@@ -1495,6 +1541,8 @@ int main(int argc, char* argv[])
   {
     stop_on_first_fail = command_line::get_arg(g_vm, arg_stop_on_fail);
   }
+
+  g_report_block_stats = command_line::has_arg(g_vm, arg_report_block_stats) && command_line::get_arg(g_vm, arg_report_block_stats);
 
   const int32_t worker_id = command_line::get_arg(g_vm, arg_worker_id);
   const bool is_worker = (worker_id >= 0);
@@ -1657,6 +1705,8 @@ int main(int argc, char* argv[])
       rep.tests_running_time = tests_running_time;
       rep.failed_tests = failed_tests;
       rep.skip_all_till_the_end = skip_all_till_the_end;
+      if (g_report_block_stats)
+        rep.block_stats = g_test_block_stats;
       rep.exit_code = (serious_failures_count == 0 ? 0 : 1);
 
       if (g_runner)
@@ -1692,6 +1742,22 @@ int main(int argc, char* argv[])
       }
 
       std::cout << concolor::normal << std::endl;
+
+      if (g_report_block_stats)
+      {
+        LOG_PRINT2(BLOCK_STATS_LOG_FILENAME, "===== FINAL BLOCK STATS REPORT (" << g_test_block_stats.size() << " tests) =====", LOG_LEVEL_0);
+        for (const auto& p : g_test_block_stats)
+        {
+          LOG_PRINT2(BLOCK_STATS_LOG_FILENAME,
+            p.first
+            << "  chain_size=" << p.second.blockchain_size
+            << "  top_height=" << p.second.top_block_height
+            << "  alt_blocks=" << p.second.alt_blocks_count
+            << "  pool_txs="   << p.second.pool_tx_count,
+            LOG_LEVEL_0);
+        }
+        print_block_stats_table(g_test_block_stats);
+      }
     }
   }
 

--- a/tests/core_tests/parallel/parallel_test_runner.cpp
+++ b/tests/core_tests/parallel/parallel_test_runner.cpp
@@ -289,6 +289,11 @@ int parallel_test_runner::print_aggregated_report_and_return_rc(uint32_t process
 
   std::cout << concolor::normal << '\n';
 
+  std::vector<std::pair<std::string, test_block_stats>> all_block_stats;
+  for (const auto& r : reps)
+    all_block_stats.insert(all_block_stats.end(), r.block_stats.begin(), r.block_stats.end());
+  print_block_stats_table(all_block_stats);
+
   if (!reps.empty())
     (void)write_workers_report_file(processes, reps);
 
@@ -296,6 +301,49 @@ int parallel_test_runner::print_aggregated_report_and_return_rc(uint32_t process
     return 1;
 
   return serious_failures_count == 0 ? 0 : 1;
+}
+
+void print_block_stats_table(const std::vector<std::pair<std::string, test_block_stats>>& stats)
+{
+  if (stats.empty())
+    return;
+
+  std::vector<std::pair<std::string, test_block_stats>> sorted = stats;
+  std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b)
+    { return a.first < b.first; });
+
+  size_t max_name_len = std::string("TEST").size();
+  for (const auto& p : sorted)
+    max_name_len = std::max(max_name_len, p.first.size());
+
+  const int name_col = static_cast<int>(max_name_len) + 2;
+  const int num_col  = 12;
+  const int last_col = 10;
+  const size_t total_width = static_cast<size_t>(name_col) + 3 * num_col + last_col;
+
+  std::cout << concolor::bright_white
+    << "BLOCK STATS PER TEST (end-of-test snapshot, " << sorted.size() << " entries):"
+    << concolor::normal << '\n';
+  std::cout << std::left  << std::setw(name_col) << "TEST"
+    << std::right
+    << std::setw(num_col)  << "chain_size"
+    << std::setw(num_col)  << "top_height"
+    << std::setw(num_col)  << "alt_blocks"
+    << std::setw(last_col) << "pool_txs"
+    << '\n';
+  std::cout << std::string(total_width, '-') << '\n';
+
+  for (const auto& p : sorted)
+  {
+    std::cout << std::left  << std::setw(name_col) << p.first
+      << std::right
+      << std::setw(num_col)  << p.second.blockchain_size
+      << std::setw(num_col)  << p.second.top_block_height
+      << std::setw(num_col)  << p.second.alt_blocks_count
+      << std::setw(last_col) << p.second.pool_tx_count
+      << '\n';
+  }
+  std::cout << '\n';
 }
 
 void parallel_test_runner::print_worker_failure_reasons(uint32_t processes, const std::vector<int>& worker_exit_codes) const
@@ -619,6 +667,19 @@ bool parallel_test_runner::write_worker_report_file(const worker_report& rep) co
     }
     root.add_child("tests_running_time", times_arr);
 
+    pt::ptree block_stats_arr;
+    for (const auto& it : rep.block_stats)
+    {
+      pt::ptree node;
+      node.put("name", it.first);
+      node.put("chain_size", it.second.blockchain_size);
+      node.put("top_height", it.second.top_block_height);
+      node.put("alt_blocks", static_cast<uint64_t>(it.second.alt_blocks_count));
+      node.put("pool_txs",   static_cast<uint64_t>(it.second.pool_tx_count));
+      block_stats_arr.push_back(std::make_pair("", node));
+    }
+    root.add_child("block_stats", block_stats_arr);
+
     std::ofstream out(get_worker_report_path(rep.worker_id));
     if (!out.is_open())
       return false;
@@ -666,6 +727,20 @@ bool parallel_test_runner::read_worker_report_file(uint32_t worker_id, worker_re
       const uint64_t ms = node.get<uint64_t>("ms", 0);
       if (!name.empty())
         rep.tests_running_time.emplace_back(name, ms);
+    }
+
+    for (const auto& v : root.get_child("block_stats", pt::ptree()))
+    {
+      const auto& node = v.second;
+      const std::string name = node.get<std::string>("name", "");
+      if (name.empty())
+        continue;
+      test_block_stats s;
+      s.blockchain_size  = node.get<uint64_t>("chain_size", 0);
+      s.top_block_height = node.get<uint64_t>("top_height", 0);
+      s.alt_blocks_count = static_cast<size_t>(node.get<uint64_t>("alt_blocks", 0));
+      s.pool_tx_count    = static_cast<size_t>(node.get<uint64_t>("pool_txs", 0));
+      rep.block_stats.emplace_back(name, s);
     }
 
     return true;

--- a/tests/core_tests/parallel/parallel_test_runner.h
+++ b/tests/core_tests/parallel/parallel_test_runner.h
@@ -4,6 +4,7 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -16,6 +17,17 @@ struct test_job
   std::string name;
   std::function<bool()> run;
 };
+
+// enabled via --report-block-stats
+struct test_block_stats
+{
+  uint64_t blockchain_size  = 0; // get_current_blockchain_size()
+  uint64_t top_block_height = 0; // get_top_block_height()
+  size_t   alt_blocks_count = 0; // get_alternative_blocks_count()
+  size_t   pool_tx_count    = 0; // get_pool_transactions_count()
+};
+// pretty-prints for test_block_stats
+void print_block_stats_table(const std::vector<std::pair<std::string, test_block_stats>>& stats);
 
 namespace coretests_shm
 {
@@ -129,6 +141,9 @@ public:
     std::vector<std::pair<std::string, uint64_t>> tests_running_time;
     std::set<std::string> failed_tests;
     bool skip_all_till_the_end = false;
+
+    // End-of-test block stats per test executed by this worker.
+    std::vector<std::pair<std::string, test_block_stats>> block_stats;
 
     int exit_code = 0;
   };


### PR DESCRIPTION
Example of run:
```
coretests.exe --multiprocess-run 8 --report-block-stats
coretests.exe --report-block-stats
```

<img width="1056" height="751" alt="image" src="https://github.com/user-attachments/assets/c2670b3b-036b-42dc-97e7-05e39697b767" />
