### PR TITLE
Fix unaligned chacha iv/key access crash on ARM32

### DIFF
--- a/src/crypto/chacha.c
+++ b/src/crypto/chacha.c
@@ -19,11 +19,31 @@ Public domain.
 #define U32V(v) ((uint32_t)(v) & UINT32_C(0xFFFFFFFF))
 
 /*
- * The following macros load words from an array of bytes with
- * different types of endianness, and vice versa.
+ * The following functions load/store words from an array of bytes with
+ * little-endian ordering.
+ *
+ * They must not cast the byte pointer to uint32_t*: callers routinely pass
+ * unaligned pointers (e.g. chacha_iv sits at offset 1 inside the packed
+ * wallet keys_file_data struct), and the cast lets the compiler emit
+ * alignment-assuming instructions (LDM/LDRD on ARM32) that fault on
+ * unaligned addresses. memcpy compiles to a single load/store where
+ * unaligned access is allowed and to safe byte accesses elsewhere.
  */
-#define U8TO32_LITTLE(p) SWAP32LE(((uint32_t*)(p))[0])
-#define U32TO8_LITTLE(p, v) (((uint32_t*)(p))[0] = SWAP32LE(v))
+static inline uint32_t u8to32_little(const void* p)
+{
+  uint32_t v;
+  memcpy(&v, p, sizeof(v));
+  return SWAP32LE(v);
+}
+
+static inline void u32to8_little(void* p, uint32_t v)
+{
+  v = SWAP32LE(v);
+  memcpy(p, &v, sizeof(v));
+}
+
+#define U8TO32_LITTLE(p) u8to32_little(p)
+#define U32TO8_LITTLE(p, v) u32to8_little((p), (v))
 
 #define ROTATE(v,c) (rol32(v,c))
 #define XOR(v,w) ((v) ^ (w))


### PR DESCRIPTION
## Bug

On 32-bit ARM (e.g. Android armeabi-v7a), every wallet keys-file open/save crashes with SIGBUS in `chacha8`/`chacha_with_counter`.

## Root cause

`wallet2::keys_file_data` declares `uint8_t version;` directly before `crypto::chacha_iv iv;`. Since `chacha_iv` is `#pragma pack(1)` (alignof 1), the iv is placed at offset 1 — so `&kf_data.iv` passed to `chacha8()` / `chacha20()` in `wallet2::load_keys` / `store_keys` is always misaligned.

`chacha.c` loads words through `U8TO32_LITTLE`, which casts the byte pointer to `uint32_t*`. The cast promises alignment, so on ARM32 the compiler emits `LDM`/`LDRD` — instructions that fault on unaligned addresses unconditionally (regardless of SCTLR.A). 64-bit targets tolerate unaligned plain loads, which is why the bug only manifests on 32-bit ARM.

## Fix

Replace the pointer-cast macros in `chacha.c` with `memcpy`-based inline helpers. `memcpy` of 4 bytes compiles to the identical single load/store on platforms that permit unaligned access and to safe byte accesses on strict-alignment targets.

## Verification

- arm64/x86_64: compiled objects are byte-identical before/after the change (no codegen or performance impact).
- armeabi-v7a (NDK r27, `-O2 -mno-unaligned-access`): the faulting `ldrd`/`ldm` on caller-supplied pointers are gone; wallet open/save no longer crashes on 32-bit devices.