### PR TITLE
wallet: validate ROMix KDF cost parameters before decryption

### DIFF
--- a/src/crypto/wallet_kdf.h
+++ b/src/crypto/wallet_kdf.h
@@ -17,6 +17,13 @@ namespace crypto
     #include "keccak.h"
   }
 
+  constexpr uint8_t ROMIX_KECCAK_N_LOG2 = 10;
+
+  inline bool is_romix_keccak_cost_within_limits(uint8_t N_log2, uint8_t phase2_log2_reduction, uint8_t max_N_log2)
+  {
+    return N_log2 >= ROMIX_KECCAK_N_LOG2 && N_log2 <= max_N_log2 && phase2_log2_reduction < N_log2;
+  }
+
   // memory-hard password stretching for wallet file encryption
   //
   // construction is the ROMix algorithm from scrypt (C. Percival, 2009, "Stronger Key Derivation via Sequential Memory-Hard Functions"),
@@ -27,8 +34,8 @@ namespace crypto
     uint8_t N_log2, uint8_t phase2_log2_reduction,
     uint8_t (&out_stretched)[32])
   {
-    if (N_log2 < 10)
-      N_log2 = 10; // 32kb ram min
+    if (N_log2 < ROMIX_KECCAK_N_LOG2)
+      N_log2 = ROMIX_KECCAK_N_LOG2; // 32kb ram min
     if (N_log2 > 30)
       N_log2 = 30; // 32gb ram max
     const uint64_t N = (uint64_t)1 << N_log2;

--- a/src/crypto/wallet_kdf.h
+++ b/src/crypto/wallet_kdf.h
@@ -17,7 +17,8 @@ namespace crypto
     #include "keccak.h"
   }
 
-  constexpr uint8_t ROMIX_KECCAK_N_LOG2 = 10;
+  constexpr uint8_t ROMIX_KECCAK_N_LOG2_MIN = 10;
+  constexpr uint8_t ROMIX_KECCAK_N_LOG2_MAX = 30;
 
   // memory-hard password stretching for wallet file encryption
   //
@@ -29,10 +30,10 @@ namespace crypto
     uint8_t N_log2, uint8_t phase2_log2_reduction,
     uint8_t (&out_stretched)[32])
   {
-    if (N_log2 < ROMIX_KECCAK_N_LOG2)
-      N_log2 = ROMIX_KECCAK_N_LOG2; // 32kb ram min
-    if (N_log2 > 30)
-      N_log2 = 30; // 32gb ram max
+    if (N_log2 < ROMIX_KECCAK_N_LOG2_MIN)
+      N_log2 = ROMIX_KECCAK_N_LOG2_MIN; // 32kb ram min
+    if (N_log2 > ROMIX_KECCAK_N_LOG2_MAX)
+      N_log2 = ROMIX_KECCAK_N_LOG2_MAX; // 32gb ram max
     const uint64_t N = (uint64_t)1 << N_log2;
     const uint64_t mask = N - 1; // N is power of 2 -> "x & mask" == "x % N"
 

--- a/src/crypto/wallet_kdf.h
+++ b/src/crypto/wallet_kdf.h
@@ -19,11 +19,6 @@ namespace crypto
 
   constexpr uint8_t ROMIX_KECCAK_N_LOG2 = 10;
 
-  inline bool is_romix_keccak_cost_within_limits(uint8_t N_log2, uint8_t phase2_log2_reduction, uint8_t max_N_log2)
-  {
-    return N_log2 >= ROMIX_KECCAK_N_LOG2 && N_log2 <= max_N_log2 && phase2_log2_reduction < N_log2;
-  }
-
   // memory-hard password stretching for wallet file encryption
   //
   // construction is the ROMix algorithm from scrypt (C. Percival, 2009, "Stronger Key Derivation via Sequential Memory-Hard Functions"),

--- a/src/currency_core/currency_config.h
+++ b/src/currency_core/currency_config.h
@@ -207,6 +207,7 @@ static_assert(CURRENCY_FORMATION_VERSION == 103);
 #define WALLET_KDF_ALGO_NONE                            0
 #define WALLET_KDF_ALGO_ROMIX_KECCAK                    1
 #define WALLET_KDF_ROMIX_N_LOG2                         20 //phase 1: the buffer size is V = 2^(N_log2) * 32 bytes, where N_log2 = 20 -> 1 million blocks * 32 bytes = 32 MiB
+#define WALLET_KDF_ROMIX_N_LOG2_MAX                     22
 #define WALLET_KDF_ROMIX_PHASE2_LOG2_REDUCTION          3  //phase 2: iteration reduction: 0 = full N phase 2 iterations, 1 = N/2 iterations 2 = N/4, 3 = N/8, 4 = N/16 ... (still 32 MiB at N_log2=20)
 #define WALLET_KDF_SALT_SIZE                            16
 
@@ -347,6 +348,7 @@ static_assert(CURRENCY_FORMATION_VERSION == 103);
 
 static_assert(CURRENCY_MINER_TX_MAX_OUTS <= CURRENCY_TX_MAX_ALLOWED_OUTS, "Miner tx must obey normal tx max outs limit");
 static_assert(PREMINE_AMOUNT / WALLET_MAX_ALLOWED_OUTPUT_AMOUNT < CURRENCY_MINER_TX_MAX_OUTS, "Premine can't be divided into reasonable number of outs");
+static_assert(WALLET_KDF_ROMIX_N_LOG2 <= WALLET_KDF_ROMIX_N_LOG2_MAX, "Default wallet KDF cost must fit the wallet-file load policy");
 
 #define CURRENCY_RELAY_TXS_MAX_COUNT                    5
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3060,6 +3060,12 @@ namespace
       return password;
     CHECK_AND_ASSERT_THROW_MES(kf_data.kdf_algo == WALLET_KDF_ALGO_ROMIX_KECCAK, "unsupported wallet KDF algo: " << (int)kf_data.kdf_algo);
     CHECK_AND_ASSERT_THROW_MES(kf_data.kdf_salt.size() == WALLET_KDF_SALT_SIZE, "unexpected wallet KDF salt size: " << kf_data.kdf_salt.size());
+    CHECK_AND_ASSERT_THROW_MES(
+      kf_data.kdf_N_log2 >= crypto::ROMIX_KECCAK_N_LOG2 &&
+      kf_data.kdf_N_log2 <= WALLET_KDF_ROMIX_N_LOG2_MAX &&
+      kf_data.kdf_phase2_log2_reduction < kf_data.kdf_N_log2,
+      "wallet KDF cost parameters are out of range: N_log2=" << (int)kf_data.kdf_N_log2 <<
+      ", phase2_log2_reduction=" << (int)kf_data.kdf_phase2_log2_reduction);
 
     uint8_t stretched[32];
     crypto::derive_key_romix_keccak(CRYPTO_HDS_WALLET_KDF_ROMIX, password.data(), password.size(),

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3061,7 +3061,7 @@ namespace
     CHECK_AND_ASSERT_THROW_MES(kf_data.kdf_algo == WALLET_KDF_ALGO_ROMIX_KECCAK, "unsupported wallet KDF algo: " << (int)kf_data.kdf_algo);
     CHECK_AND_ASSERT_THROW_MES(kf_data.kdf_salt.size() == WALLET_KDF_SALT_SIZE, "unexpected wallet KDF salt size: " << kf_data.kdf_salt.size());
     CHECK_AND_ASSERT_THROW_MES(
-      kf_data.kdf_N_log2 >= crypto::ROMIX_KECCAK_N_LOG2 &&
+      kf_data.kdf_N_log2 >= crypto::ROMIX_KECCAK_N_LOG2_MIN &&
       kf_data.kdf_N_log2 <= WALLET_KDF_ROMIX_N_LOG2_MAX &&
       kf_data.kdf_phase2_log2_reduction < kf_data.kdf_N_log2,
       "wallet KDF cost parameters are out of range: N_log2=" << (int)kf_data.kdf_N_log2 <<

--- a/tests/unit_tests/wallet_kdf_romix_test.cpp
+++ b/tests/unit_tests/wallet_kdf_romix_test.cpp
@@ -142,7 +142,7 @@ TEST(wallet_kdf_romix, cost_parameter_policy)
 
   const auto is_cost_within_limits = [max_N_log2](uint8_t N_log2, uint8_t phase2_log2_reduction)
   {
-    return N_log2 >= crypto::ROMIX_KECCAK_N_LOG2 && N_log2 <= max_N_log2 && phase2_log2_reduction < N_log2;
+    return N_log2 >= crypto::ROMIX_KECCAK_N_LOG2_MIN && N_log2 <= max_N_log2 && phase2_log2_reduction < N_log2;
   };
 
   EXPECT_FALSE(is_cost_within_limits(9, 0));

--- a/tests/unit_tests/wallet_kdf_romix_test.cpp
+++ b/tests/unit_tests/wallet_kdf_romix_test.cpp
@@ -140,16 +140,21 @@ TEST(wallet_kdf_romix, cost_parameter_policy)
 {
   const uint8_t max_N_log2 = WALLET_KDF_ROMIX_N_LOG2_MAX;
 
-  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(9, 0, max_N_log2));
-  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(10, 0, max_N_log2));
-  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2, WALLET_KDF_ROMIX_PHASE2_LOG2_REDUCTION, max_N_log2));
-  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(max_N_log2, 0, max_N_log2));
-  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(max_N_log2, (uint8_t)(max_N_log2 - 1), max_N_log2));
+  const auto is_cost_within_limits = [max_N_log2](uint8_t N_log2, uint8_t phase2_log2_reduction)
+  {
+    return N_log2 >= crypto::ROMIX_KECCAK_N_LOG2 && N_log2 <= max_N_log2 && phase2_log2_reduction < N_log2;
+  };
 
-  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits((uint8_t)(max_N_log2 + 1), 0, max_N_log2));
-  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(255, 0, max_N_log2));
-  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2,  WALLET_KDF_ROMIX_N_LOG2, max_N_log2));
-  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2, 255, max_N_log2));
+  EXPECT_FALSE(is_cost_within_limits(9, 0));
+  EXPECT_TRUE(is_cost_within_limits(10, 0));
+  EXPECT_TRUE(is_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2, WALLET_KDF_ROMIX_PHASE2_LOG2_REDUCTION));
+  EXPECT_TRUE(is_cost_within_limits(max_N_log2, 0));
+  EXPECT_TRUE(is_cost_within_limits(max_N_log2, (uint8_t)(max_N_log2 - 1)));
+
+  EXPECT_FALSE(is_cost_within_limits((uint8_t)(max_N_log2 + 1), 0));
+  EXPECT_FALSE(is_cost_within_limits(255, 0));
+  EXPECT_FALSE(is_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2, WALLET_KDF_ROMIX_N_LOG2));
+  EXPECT_FALSE(is_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2, 255));
 }
 
 TEST(wallet_kdf_romix, brute_force_cost_report)

--- a/tests/unit_tests/wallet_kdf_romix_test.cpp
+++ b/tests/unit_tests/wallet_kdf_romix_test.cpp
@@ -136,6 +136,22 @@ TEST(wallet_kdf_romix, correctness)
   ASSERT_NE(0, std::memcmp(out1, out5, 32));
 }
 
+TEST(wallet_kdf_romix, cost_parameter_policy)
+{
+  const uint8_t max_N_log2 = WALLET_KDF_ROMIX_N_LOG2_MAX;
+
+  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(9, 0, max_N_log2));
+  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(10, 0, max_N_log2));
+  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2, WALLET_KDF_ROMIX_PHASE2_LOG2_REDUCTION, max_N_log2));
+  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(max_N_log2, 0, max_N_log2));
+  EXPECT_TRUE(crypto::is_romix_keccak_cost_within_limits(max_N_log2, (uint8_t)(max_N_log2 - 1), max_N_log2));
+
+  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits((uint8_t)(max_N_log2 + 1), 0, max_N_log2));
+  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(255, 0, max_N_log2));
+  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2,  WALLET_KDF_ROMIX_N_LOG2, max_N_log2));
+  EXPECT_FALSE(crypto::is_romix_keccak_cost_within_limits(WALLET_KDF_ROMIX_N_LOG2, 255, max_N_log2));
+}
+
 TEST(wallet_kdf_romix, brute_force_cost_report)
 {
   const std::string password = "hunter2hunter2hu";


### PR DESCRIPTION

when we try to open wallet with changed bytes, for ddos our wallet, we got this

<img width="1147" height="118" alt="image" src="https://github.com/user-attachments/assets/1e57ab6e-cd56-4778-9eac-99e52c4e8746" />
